### PR TITLE
Get conversation by thread id endpoint and tests added

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -11,6 +11,7 @@ from app.resources.health import Health, DatabaseHealth, HealthDetails
 from app.resources.messages import MessageList, MessageSend, MessageById, MessageModifyById
 from app.authentication.authenticator import authenticate
 from app.resources.drafts import DraftSave, DraftById, DraftModifyById, DraftList
+from app.resources.threads import ThreadById
 from app import connector
 
 
@@ -67,6 +68,7 @@ api.add_resource(MessageModifyById, '/message/<message_id>/modify')
 api.add_resource(DraftSave, '/draft/save')
 api.add_resource(DraftModifyById, '/draft/<draft_id>/modify')
 api.add_resource(DraftById, '/draft/<draft_id>')
+api.add_resource(ThreadById, '/thread/<thread_id>')
 api.add_resource(DraftList, '/drafts')
 
 

--- a/app/resources/drafts.py
+++ b/app/resources/drafts.py
@@ -64,11 +64,11 @@ class DraftSave(Resource):
 
 
 class DraftById(Resource):
-    """Get and update message by id"""
+    """Return a draft for user"""
 
     @staticmethod
     def get(draft_id):
-        """Get message by id"""
+        """Get draft by id"""
         user_urn = g.user_urn
         # check user is authorised to view message
         message_service = Retriever()

--- a/app/resources/threads.py
+++ b/app/resources/threads.py
@@ -1,0 +1,19 @@
+from flask import g
+from flask import jsonify
+from flask_restful import Resource
+from app.repository.retriever import Retriever
+
+
+class ThreadById(Resource):
+    """Return list of messages for user"""
+
+    @staticmethod
+    def get(thread_id):
+        """Get messages by thread id"""
+        user_urn = g.user_urn
+        # check user is authorised to view message
+        message_service = Retriever()
+        conversation = message_service.retrieve_thread(thread_id, user_urn)
+        resp = jsonify(conversation)
+
+        return resp

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -725,3 +725,11 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
             with current_app.test_request_context():
                 with self.assertRaises(NotFound):
                     Retriever().retrieve_thread('anotherThreadId', 'respondent.21345')
+
+    def test_retrieve_draft_raises_server_error(self):
+        """retrieves draft when db does not exist"""
+        with app.app_context():
+            database.db.drop_all()
+            with current_app.test_request_context():
+                with self.assertRaises(InternalServerError):
+                    Retriever().retrieve_draft('draftId', 'respondent.21345')

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -29,7 +29,7 @@ class RetrieverTestCaseHelper:
                     msg_id = str(uuid.uuid4())
                     query = 'INSERT INTO secure_message(msg_id, subject, body, thread_id,' \
                             ' collection_case, reporting_unit, survey, business_name) VALUES ("{0}", "test","test",' \
-                            '"", "ACollectionCase", "AReportingUnit", "SurveyType", "ABusiness")'.format(msg_id)
+                            '"ThreadId", "ACollectionCase", "AReportingUnit", "SurveyType", "ABusiness")'.format(msg_id)
                     con.execute(query)
                     query = 'INSERT INTO status(label, msg_id, actor) VALUES("SENT", "{0}", "respondent.21345")'.format(
                         msg_id)
@@ -50,7 +50,7 @@ class RetrieverTestCaseHelper:
                     msg_id = str(uuid.uuid4())
                     query = 'INSERT INTO secure_message(msg_id, subject, body, thread_id,' \
                             ' collection_case, reporting_unit, survey, business_name) VALUES ("{0}", "test","test",' \
-                            '"", "ACollectionCase", "AReportingUnit", "SurveyType", "ABusiness")'.format(msg_id)
+                            '"ThreadId", "ACollectionCase", "AReportingUnit", "SurveyType", "ABusiness")'.format(msg_id)
                     con.execute(query)
                     query = 'INSERT INTO status(label, msg_id, actor) VALUES("SENT", "{0}", "SurveyType")'.format(
                         msg_id)
@@ -65,13 +65,13 @@ class RetrieverTestCaseHelper:
                         msg_id, sent_date)
                     con.execute(query)
                     query = 'INSERT INTO events(event, msg_id, date_time) VALUES("Read", "{0}", "{1}")'.format(
-                        msg_id, "2017-02-03 00:00:00")
+                        msg_id, str(datetime(year, month, day+2)))
                     con.execute(query)
                 if add_draft:
                     msg_id = str(uuid.uuid4())
                     query = 'INSERT INTO secure_message(msg_id, subject, body, thread_id,' \
                             ' collection_case, reporting_unit, survey, business_name) VALUES ("{0}", "test","test",' \
-                            '"", "ACollectionCase", "AReportingUnit", "SurveyType", "ABusiness")'.format(msg_id)
+                            '"ThreadId", "ACollectionCase", "AReportingUnit", "SurveyType", "ABusiness")'.format(msg_id)
                     con.execute(query)
                     query = 'INSERT INTO status(label, msg_id, actor) VALUES("DRAFT_INBOX", "{0}", "respondent.21345")'.format(
                         msg_id)
@@ -665,3 +665,63 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
             with current_app.test_request_context():
                 with self.assertRaises(InternalServerError):
                     Retriever().retrieve_message(1, 'internal.21345')
+
+    ####################################################
+    def test_all_msg_returned_for_thread_id_with_draft(self):
+        """retrieves messages for thread_id from database with draft """
+        self.populate_database(3, add_reply=True, add_draft=True)
+
+        with app.app_context():
+            with current_app.test_request_context():
+                response = Retriever().retrieve_thread('ThreadId', 'internal.21345', _survey='SurveyType')
+                self.assertEqual(len(response), 9)
+
+    def test_all_msg_returned_for_thread_id_without_draft(self):
+        """retrieves messages for thread_id from database without draft"""
+        self.populate_database(3, add_reply=True)
+
+        with app.app_context():
+            with current_app.test_request_context():
+                response = Retriever().retrieve_thread('ThreadId', 'respondent.21345')
+                self.assertEqual(len(response), 6)
+
+    def test_all_msg_returned_for_thread_id_with_draft_inbox(self):
+        """retrieves messages for thread_id from database with draft inbox"""
+        self.populate_database(3, add_reply=True, add_draft=True)
+
+        with app.app_context():
+            with current_app.test_request_context():
+                response = Retriever().retrieve_thread('ThreadId', 'respondent.21345')
+                self.assertEqual(len(response), 6)
+
+    def test_thread_returned_in_desc_order(self):
+        """check thread returned in correct order"""
+        self.populate_database(3, add_reply=True)
+
+        with app.app_context():
+            with current_app.test_request_context():
+                response = Retriever().retrieve_thread('ThreadId', 'respondent.21345')
+                self.assertEqual(len(response), 6)
+
+                sent = []
+                for message in response:
+                    sent.append(message['sent_date'])
+
+                desc_date = sorted(sent, reverse=True)
+                self.assertEqual(len(sent), 6)
+                self.assertListEqual(desc_date, sent)
+
+    def test_retrieve_thread_raises_server_error(self):
+        """retrieves messages when db does not exist"""
+        with app.app_context():
+            database.db.drop_all()
+            with current_app.test_request_context():
+                with self.assertRaises(InternalServerError):
+                    Retriever().retrieve_thread('ThreadId', 'respondent.21345')
+
+    def test_thread_returned_with_thread_id_returns_404(self):
+        """retrieves thread using id that doesn't exist"""
+        with app.app_context():
+            with current_app.test_request_context():
+                with self.assertRaises(NotFound):
+                    Retriever().retrieve_thread('anotherThreadId', 'respondent.21345')

--- a/tests/behavioural/features/steps/thread_get.py
+++ b/tests/behavioural/features/steps/thread_get.py
@@ -1,0 +1,80 @@
+import flask
+import nose.tools
+from behave import given, then, when
+from app.application import app
+from app.repository import database
+from flask import current_app
+from app.authentication.jwt import encode
+from app.authentication.jwe import Encrypter
+from app import settings
+
+url = "http://localhost:5050/thread/{0}"
+token_data = {
+            "user_urn": "000000000"
+        }
+
+headers = {'Content-Type': 'application/json', 'Authorization': ''}
+
+data = {'urn_to': 'test',
+        'urn_from': 'test',
+        'subject': 'Hello World',
+        'body': 'Test',
+        'thread_id': 'AConversation',
+        'collection_case': 'collectioncase',
+        'reporting_unit': 'AReportingUnit',
+        'business_name': 'ABusiness',
+        'survey': 'BRES'}
+
+def update_encrypted_jwt():
+    encrypter = Encrypter(_private_key=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY,
+                          _private_key_password=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY_PASSWORD,
+                          _public_key=settings.SM_USER_AUTHENTICATION_PUBLIC_KEY)
+    signed_jwt = encode(token_data)
+    return encrypter.encrypt_token(signed_jwt)
+
+headers['Authorization'] = update_encrypted_jwt()
+
+
+def reset_db():
+    with app.app_context():
+        database.db.init_app(current_app)
+        database.db.drop_all()
+        database.db.create_all()
+
+# Scenario: Respondent and internal user have a conversation and respondent retrieves the conversation
+
+
+@given("a respondent and internal user have a conversation")
+def step_impl(context):
+    reset_db()
+    for x in range(0, 2):
+        data['urn_to'] = 'internal.12344'
+        data['urn_from'] = 'respondent.122342'
+        context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
+                                                  headers=headers)
+        data['urn_to'] = 'respondent.122342'
+        data['urn_from'] = 'internal.12344'
+        context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
+                                                  headers=headers)
+
+
+@when("the respondent gets this conversation")
+def step_impl(context):
+    token_data['user_urn'] = 'respondent.122342'
+    headers['Authorization'] = update_encrypted_jwt()
+    context.response = app.test_client().get(url.format(data['thread_id']), headers=headers)
+
+
+@then("all messages from that conversation should be received")
+def step_impl(context):
+    response = flask.json.loads(context.response.data)
+    nose.tools.assert_equal(len(response), 4)
+
+
+#   Scenario: Respondent and internal user have a conversation and respondent retrieves the conversation
+
+@when("the internal user gets this conversation")
+def step_impl(context):
+    token_data['user_urn'] = 'internal.12344'
+    headers['Authorization'] = update_encrypted_jwt()
+    context.response = app.test_client().get(url.format(data['thread_id']), headers=headers)

--- a/tests/behavioural/features/steps/thread_get.py
+++ b/tests/behavioural/features/steps/thread_get.py
@@ -25,6 +25,7 @@ data = {'urn_to': 'test',
         'business_name': 'ABusiness',
         'survey': 'BRES'}
 
+
 def update_encrypted_jwt():
     encrypter = Encrypter(_private_key=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY,
                           _private_key_password=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY_PASSWORD,
@@ -47,7 +48,7 @@ def reset_db():
 @given("a respondent and internal user have a conversation")
 def step_impl(context):
     reset_db()
-    for x in range(0, 2):
+    for _ in range(0, 2):
         data['urn_to'] = 'internal.12344'
         data['urn_from'] = 'respondent.122342'
         context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),

--- a/tests/behavioural/features/thread_get.feature
+++ b/tests/behavioural/features/thread_get.feature
@@ -1,0 +1,11 @@
+Feature: Get thread by id Endpoint
+
+  Scenario: Respondent and internal user have a conversation and respondent retrieves the conversation
+    Given a respondent and internal user have a conversation
+    When the respondent gets this conversation
+    Then all messages from that conversation should be received
+
+  Scenario: Respondent and internal user have a conversation and internal user retrieves the conversation
+    Given a respondent and internal user have a conversation
+    When the internal user gets this conversation
+    Then all messages from that conversation should be received

--- a/tests/behavioural/features/thread_get.feature
+++ b/tests/behavioural/features/thread_get.feature
@@ -9,3 +9,26 @@ Feature: Get thread by id Endpoint
     Given a respondent and internal user have a conversation
     When the internal user gets this conversation
     Then all messages from that conversation should be received
+
+  Scenario: Respondent and internal user have a conversation, including a draft, and respondent retrieves the conversation
+    Given a respondent and internal user have a conversation
+    And internal user creates a draft
+    When the respondent gets this conversation
+    Then all messages from that conversation should be received
+
+  Scenario: Respondent and internal user have a conversation, including a draft, and internal user retrieves the conversation
+    Given a respondent and internal user have a conversation
+    And internal user creates a draft
+    When the internal user gets this conversation
+    Then all messages from that conversation should be received including draft
+
+  Scenario: Respondent and internal user have a conversation and internal user retrieves that conversation from multiple conversations
+    Given a respondent and internal user have a conversation
+    And internal user has multiple conversations
+    When the internal user gets this conversation
+    Then all messages from that conversation should be received
+
+  Scenario: User tries to retrieve a conversation that does not exist
+    Given a respondent picks a conversation that does not exist
+    When the respondent gets this conversation
+    Then a 404 HTTP response is returned


### PR DESCRIPTION
**What is the context of this PR?**

Link to Trello card

https://trello.com/c/MESJU17r/277-ts-184-as-a-user-i-want-to-be-able-to-retrieve-a-conversational-thread-of-messages-by-thread-id%7C8%7C

Describe what you have changed and why, link to other PRs or Issues as appropriate.

-Added a new endpoint 'ThreadById'
-Added new retriever function for thread id
-Unit tests for Retrieve_thread function 
-BDD test for the new feature

**How to review**

Any notes for the reviewer  (include screenshots if appropriate).
