### PR TITLE
Ts 185 change function names for codecy checks

### DIFF
--- a/tests/behavioural/features/steps/draft_get.py
+++ b/tests/behavioural/features/steps/draft_get.py
@@ -106,7 +106,7 @@ def step_impl(context):
 
 #   Scenario: User is retrieving the etag from the header
 @given("there is a draft")
-def step_impl(context):
+def step_impl_there_is_a_draft(context):
     data.update({'urn_to': 'test',
                  'urn_from': 'test',
                  'subject': 'test',
@@ -122,7 +122,7 @@ def step_impl(context):
 
 
 @then("an etag should be sent with the draft")
-def step_impl(context):
+def step_impl_etag_should_be_sent_with_draft(context):
     etag = context.response.headers.get('ETag')
     nose.tools.assert_is_not_none(etag)
     nose.tools.assert_true(len(etag) == 40)
@@ -130,5 +130,5 @@ def step_impl(context):
 
 #   common
 @when('the user requests the draft')
-def step_impl(context):
+def step_impl_the_user_requests_draft(context):
     context.response = app.test_client().get(url.format(context.resp_data['msg_id']), headers=headers)

--- a/tests/behavioural/features/steps/draft_get.py
+++ b/tests/behavioural/features/steps/draft_get.py
@@ -41,7 +41,7 @@ with app.app_context():
 #   Scenario: User requests draft
 
 @given('a user requests a valid draft')
-def step_impl(context):
+def step_impl_user_requests_valid_draft(context):
     data.update({'urn_to': 'test',
                  'urn_from': 'test',
                  'subject': 'test',
@@ -57,33 +57,33 @@ def step_impl(context):
 
 
 @then('the draft is returned')
-def step_impl(context):
+def step_impl_assert_draft_is_retuned(context):
     response = json.loads(context.response.data)
     nose.tools.assert_equal(response['msg_id'], context.resp_data['msg_id'])
 
 
 @then('a success response is returned')
-def step_impl(context):
+def step_impl_assert_200_returned(context):
     nose.tools.assert_equal(context.response.status_code, 200)
 
 
 #   Scenario: User requests draft that does not exist
 
 @given('a user wants a draft that does not exist')
-def step_impl(context):
+def step_impl_user_request_non_existant_draft(context):
     context.resp_data = dict(msg_id='')
     context.resp_data['msg_id'] = str(uuid.uuid4())
 
 
 @then('the user receives a draft not found response')
-def step_impl(context):
+def step_impl_assert_404_returned(context):
     nose.tools.assert_equal(context.response.status_code, 404)
 
 
 #   Scenario: User requests draft not authorised to view
 
 @given('a user is not authorised')
-def step_impl(self, context):
+def step_impl_user_not_authorised(self, context):
     #   waiting for  authorisation to be implemented
     data.update({'urn_to': 'test',
                  'urn_from': 'test',
@@ -100,7 +100,7 @@ def step_impl(self, context):
 
 
 @then('the user is forbidden from viewing draft')
-def step_impl(context):
+def step_impl_assert_403_returned(context):
     nose.tools.assert_equal(context.response.status_code, 403)
 
 

--- a/tests/behavioural/features/steps/draft_post.py
+++ b/tests/behavioural/features/steps/draft_post.py
@@ -40,7 +40,7 @@ with app.app_context():
 
 # Scenario 1: Save a valid draft get a 201 return
 @given('a valid draft')
-def step_impl(context):
+def step_impl_valid_draft(context):
     data.update({'urn_to': 'test',
                  'urn_from': 'test',
                  'subject': 'test',
@@ -54,7 +54,7 @@ def step_impl(context):
 
 # Scenario 2: Save a draft with body field empty return 201
 @given('a draft has an body field set to empty')
-def step_impl(context):
+def step_impl_draft_with_empty_body(context):
     data.update({'urn_to': 'test',
                  'urn_from': 'test',
                  'subject': 'test',
@@ -68,7 +68,7 @@ def step_impl(context):
 
 # Scenario 3: Save a draft with a message ID will return 400
 @given('a draft including a msg_id')
-def step_impl(context):
+def step_impl_draft_with_msg_id(context):
     data.update({'msg_id': 'Amsgid',
                  'urn_to': 'test',
                  'urn_from': 'test',
@@ -83,7 +83,7 @@ def step_impl(context):
 
 # Scenario 4: Save a draft with a to field too large return 400
 @given('a draft with to field too large in size')
-def step_impl(context):
+def step_impl_draft_with_to_field_too_large(context):
     data.update({'urn_to': 'x' * (constants.MAX_TO_LEN+1),
                  'urn_from': 'test',
                  'subject': 'test',
@@ -97,7 +97,7 @@ def step_impl(context):
 
 # Scenario 5: Save a draft with a from field too large return 400
 @given('a draft with from field too large in size')
-def step_impl(context):
+def step_impl_draft_with_from_field_too_large(context):
     data.update({'urn_to': 'test',
                  'urn_from': 'x' * (constants.MAX_FROM_LEN+1),
                  'subject': 'test',
@@ -111,7 +111,7 @@ def step_impl(context):
 
 # Scenario 6: Save a draft with a body field too large return 400
 @given('a draft with body field too large in size')
-def step_impl(context):
+def step_impl_draft_with_body_field_too_large(context):
     data.update({'urn_to': 'test',
                  'urn_from': 'test',
                  'subject': 'test',
@@ -125,7 +125,7 @@ def step_impl(context):
 
 # Scenario 7: Save a draft with a subject field too large return 400
 @given('a draft with subject field too large in size')
-def step_impl(context):
+def step_impl_draft_with_subject_field_too_large(context):
     data.update({'urn_to': 'test',
                  'urn_from': 'test',
                  'subject': 'x' * (constants.MAX_SUBJECT_LEN+1),
@@ -139,7 +139,7 @@ def step_impl(context):
 
 # Scenario 8: Save a draft with an empty from field return 400
 @given('a draft with a from field set as empty')
-def step_impl(context):
+def step_impl_draft_with_empty_from_field(context):
     data.update({'urn_to': 'test',
                  'urn_from': '',
                  'subject': 'test',
@@ -153,7 +153,7 @@ def step_impl(context):
 
 # Scenario 9: Save a draft with an empty survey field return 400
 @given('a draft with a survey field set as empty')
-def step_impl(context):
+def step_impl_draft_with_empty_survey_field(context):
     data.update({'urn_to': 'test',
                  'urn_from': 'test',
                  'subject': 'test',
@@ -167,7 +167,7 @@ def step_impl(context):
 
 # Scenario: As a user the message id for my saved draft should be returned when saving a draft
 @given("a user creates a valid draft")
-def step_impl(context):
+def step_impl_user_creates_valid_draft(context):
     context.draft = {'urn_to': 'test',
                      'urn_from': 'test',
                      'subject': 'test',
@@ -180,17 +180,17 @@ def step_impl(context):
 
 
 @when("the user saves this draft")
-def step_impl(context):
+def step_impl_user_saves_draft(context):
     context.response = app.test_client().post(url, data=json.dumps(context.draft), headers=headers)
 
 
 @then("the message id should be returned in the response")
-def step_impl(context):
+def step_implmsg_id_returned(context):
     resp_data = json.loads(context.response.data)
     nose.tools.assert_true(resp_data['msg_id'] is not None)
 
 
 # Common
 @when('the draft is saved')
-def step_impl(context):
+def step_impl_draft_is_saved(context):
     context.response = app.test_client().post(url, data=json.dumps(data), headers=headers)

--- a/tests/behavioural/features/steps/draft_put.py
+++ b/tests/behavioural/features/steps/draft_put.py
@@ -49,7 +49,7 @@ headers['Authorization'] = update_encrypted_jwt()
 
 # Scenario 1: A user edits a previously saved draft
 @given('a user edits a previously saved draft')
-def step_impl(context):
+def step_impl_user_edits_saved_draft(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -69,7 +69,7 @@ def step_impl(context):
 
 
 @when('the user saves the draft')
-def step_impl(context):
+def step_impl_user_saves_the_draft(context):
     if 'ETag' in headers:
         del headers['ETag']
     if hasattr(context, 'etag'):
@@ -78,13 +78,13 @@ def step_impl(context):
 
 
 @then('a success response is given')
-def step_impl(context):
+def step_impl_success_returned(context):
     nose.tools.assert_equal(context.response.status_code, 200)
 
 
 # Scenario 2: A user edits a draft that has not been previously saved
 @given('a user edits a non-existing draft')
-def step_impl(context):
+def step_impl_user_edits_non_existant_draft(context):
     data.update({'msg_id': '001',
                  'urn_to': 'internal.000000',
                  'urn_from': 'respondent.000000',
@@ -101,7 +101,7 @@ def step_impl(context):
 
 # Scenario 3: A user edits a draft that has a too large to attribute
 @given("a user modifies a draft with a to attribute that is too big")
-def step_impl(context):
+def step_impl_modifies_draft_to_attribute_too_big(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -120,7 +120,7 @@ def step_impl(context):
 
 # Scenario 4: A user edits a draft that has a too large from attribute
 @given("a user modifies a draft with a from attribute that is too big")
-def step_impl(context):
+def step_impl_user_modifies_draft_from_attribute_too_big(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -139,7 +139,7 @@ def step_impl(context):
 
 # Scenario 5: A user edits a draft that has a too large body attribute
 @given("a user modifies a draft with a body attribute that is too big")
-def step_impl(context):
+def step_impl_user_modifies_draft_body_attribute_too_big(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -158,7 +158,7 @@ def step_impl(context):
 
 # Scenario 6: A user edits a draft that has a too large subject attribute
 @given("a user modifies a draft with a subject attribute that is too big")
-def step_impl(context):
+def step_impl_user_modifies_draft_subject_attribute_too_big(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -177,7 +177,7 @@ def step_impl(context):
 
 # Scenario 7: A user edits a draft not including a to attribute
 @given("a user modifies a draft not adding a to attribute")
-def step_impl(context):
+def step_impl_user_modifies_draft_no_to_attribute(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -198,7 +198,7 @@ def step_impl(context):
 
 # Scenario 8: A user edits a draft not including a body attribute
 @given("a user modifies a draft not adding a body attribute")
-def step_impl(context):
+def step_impl_user_modifies_draft_no_body(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -219,7 +219,7 @@ def step_impl(context):
 
 # Scenario 9: A user edits a draft not including a subject attribute
 @given("a user modifies a draft not adding a subject attribute")
-def step_impl(context):
+def step_impl_user_modifies_draft_no_subject(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -240,7 +240,7 @@ def step_impl(context):
 
 # Scenario 10: A user edits a draft not including a subject attribute
 @given("a user modifies a draft not adding a thread id attribute")
-def step_impl(context):
+def step_impluser_modifies_draft_no_thread_id(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -261,7 +261,7 @@ def step_impl(context):
 
 # Scenario 11: A user edits a draft where msg id in url and in the message body do not match
 @given("a user tries to modify a draft with mismatched msg ids")
-def step_impl(context):
+def step_impl_user_modifies_draft_with_mismatched_msg_id(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data), headers=headers)
     post_resp = json.loads(add_draft.data)
     context.msg_id = post_resp['msg_id']
@@ -279,7 +279,7 @@ def step_impl(context):
 
 # Scenario 12: A user is editing a draft while another user tries to modify the same draft
 @given("a draft message is being edited")
-def step_impl(context):
+def step_impl_draft_message_is_being_edited(context):
         add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data),
                                            headers=headers)
         post_resp = json.loads(add_draft.data)
@@ -304,7 +304,7 @@ def step_impl(context):
 
 
 @when("another user tries to modify the same draft message")
-def step_impl(context):
+def step_impl_another_user_tries_to_modify_same_draft(context):
     data.update({'msg_id': context.msg_id,
                  'urn_to': 'internal.000000',
                  'urn_from': 'respondent.000000',
@@ -323,13 +323,13 @@ def step_impl(context):
 
 
 @then("a conflict error is returned")
-def step_impl(context):
+def step_impl_conflict_returned(context):
     nose.tools.assert_equal(context.response.status_code, 409)
 
 
 #  Scenario: User retrieves etag from the header when modifying a draft
 @given('there is a draft to be modified')
-def step_impl(context):
+def step_impl_there_is_a_draft_to_be_modified(context):
     add_draft = app.test_client().post('http://localhost:5050/draft/save', data=json.dumps(post_data),
                                        headers=headers)
     post_resp = json.loads(add_draft.data)
@@ -340,7 +340,7 @@ def step_impl(context):
 
 
 @when('the user modifies the draft')
-def step_impl(context):
+def step_impl_the_user_modifies_the_draft(context):
     data.update({'msg_id':context.msg_id,
                  'urn_to': 'internal.000000',
                  'urn_from': 'respondent.000000',
@@ -359,7 +359,7 @@ def step_impl(context):
 
 
 @then("a new etag should be returned to the user")
-def step_impl(context):
+def step_impl_new_etag_should_be_returned(context):
     etag = context.response.headers.get('ETag')
     nose.tools.assert_is_not_none(etag)
     nose.tools.assert_true(len(etag) == 40)

--- a/tests/behavioural/features/steps/drafts_get.py
+++ b/tests/behavioural/features/steps/drafts_get.py
@@ -47,7 +47,7 @@ def reset_db():
 
 
 @given('the user has created and saved multiple drafts')
-def step_impl(context):
+def step_impl_user_has_created__and_saved_multiple_drafts(context):
     reset_db()
     data.update({'urn_to': 'test',
                  'urn_from': 'respondent.2134',
@@ -63,14 +63,14 @@ def step_impl(context):
 
 
 @when("the user requests drafts")
-def step_impl(context):
+def step_impl_user_requests_drafts(context):
     token_data['user_urn'] = 'respondent.2134'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}?limit={1}&page={2}'.format(url, 7, 1), headers=headers)
 
 
 @then("only the users drafts are returned")
-def step_impl(context):
+def step_impl_only_the_users_drafts_are_returned(context):
     response = flask.json.loads(context.response.data)
     for x in range(0, len(response['messages'])):
         nose.tools.assert_equal(response['messages'][x]['labels'], ['DRAFT'])
@@ -82,14 +82,14 @@ def step_impl(context):
 #   Scenario: User requests second page of list of drafts
 
 @when("the user requests second page of drafts")
-def step_impl(context):
+def step_impl_the_user_requests_second_page_of_drafts(context):
     token_data['user_urn'] = 'respondent.2134'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}?limit={1}&page={2}'.format(url, 7, 2), headers=headers)
 
 
 @then("user will get drafts from second page of pagination")
-def step_impl(context):
+def step_impl_user_will_get_drafts_from_second_page_of_pagination(context):
     response = flask.json.loads(context.response.data)
     for x in range(0, len(response['messages'])):
         nose.tools.assert_equal(response['messages'][x]['labels'], ['DRAFT'])

--- a/tests/behavioural/features/steps/message_get.py
+++ b/tests/behavioural/features/steps/message_get.py
@@ -38,7 +38,7 @@ headers['Authorization'] = update_encrypted_jwt()
 
 # Scenario: Retrieve a message with correct message ID
 @given("there is a message to be retrieved")
-def step_impl(context):
+def step_impl_there_is_a_message_to_be_retrieved(context):
     data['urn_to'] = 'internal.12344'
     data['urn_from'] = 'respondent.122342'
     context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
@@ -48,31 +48,31 @@ def step_impl(context):
 
 
 @when("the get request is made with a correct message id")
-def step_impl(context):
+def step_impl_the_get_request_is_made_with_a_correct_message_id(context):
     new_url = url+context.msg_id
     context.response = app.test_client().get(new_url, headers=headers)
 
 
 @then("a 200 HTTP response is returned")
-def step_impl(context):
+def step_impl_a_200_http_response_is_returned(context):
     nose.tools.assert_equal(context.response.status_code, 200)
 
 
 # Scenario: Retrieve a message with incorrect message ID
 @when("the get request has been made with an incorrect message id")
-def step_impl(context):
+def step_impl_the_get_request_has_been_made_with_incorrect_message_id(context):
     new_url = url+str(uuid.uuid4())
     context.response = app.test_client().get(new_url, headers=headers)
 
 
 @then("a 404 HTTP response is returned")
-def step_impl(context):
+def step_impl_a_404_http_response_is_returned(context):
     nose.tools.assert_equal(context.response.status_code, 404)
 
 
 # Scenario: Respondent sends message and retrieves the same message with it's labels
 @given("a respondent sends a message")
-def step_impl(context):
+def step_impl_a_respondent_sends_a_message(context):
     data['urn_to'] = 'internal.12344'
     data['urn_from'] = 'respondent.122342'
     context.response = app.test_client().post("http://localhost:5050/message/send",
@@ -82,7 +82,7 @@ def step_impl(context):
 
 
 @when("the respondent wants to see the message")
-def step_impl(context):
+def step_impl_the_respondent_wants_to_see_the_message(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     new_url = url+context.msg_id
@@ -90,14 +90,14 @@ def step_impl(context):
 
 
 @then("the retrieved message should have the label SENT")
-def step_impl(context):
+def step_impl_the_retrieved_message_should_have_label_sent(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_equal(response['labels'], ['SENT'])
 
 
 # Scenario: Internal user sends message and retrieves the same message with it's labels
 @given("an internal user sends a message")
-def step_impl(context):
+def step_impl_an_internal_user_sends_a_message(context):
     data['urn_to'] = 'respondent.122342'
     data['urn_from'] = 'internal.12344'
     context.response = app.test_client().post("http://localhost:5050/message/send",
@@ -107,7 +107,7 @@ def step_impl(context):
 
 
 @when("the internal user wants to see the message")
-def step_impl(context):
+def step_impl_the_internal_user_wants_to_see_the_message(context):
     token_data['user_urn'] = 'internal.12344'
     headers['Authorization'] = update_encrypted_jwt()
     new_url = url+context.msg_id
@@ -116,7 +116,7 @@ def step_impl(context):
 
 #  Scenario: Internal user sends message and respondent retrieves the same message with it's labels
 @then("the retrieved message should have the labels INBOX and UNREAD")
-def step_impl(context):
+def step_impl_the_retrieved_message_should_havethe_labels_inbox_and_unread(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_true(len(response['labels']), 2)
     nose.tools.assert_true('INBOX' in response['labels'])

--- a/tests/behavioural/features/steps/message_post.py
+++ b/tests/behavioural/features/steps/message_post.py
@@ -54,13 +54,13 @@ def before_scenario(context):
 
 # Scenario 1: Submitting a valid message and receiving a 201
 @given('a valid message')
-def step_impl(context):
+def step_impl_a_valid_message(context):
     before_scenario(context)
 
 
 # Scenario 2: Send a draft and receive a 201
 @given('a message is identified as a draft')
-def step_impl(context):
+def step_impl_a_message_is_a_draft(context):
     context.post_draft = app.test_client().post("http://localhost:5050/draft/save", data=json.dumps(data),
                                                 headers=headers)
     msg_resp = json.loads(context.post_draft.data)
@@ -78,62 +78,62 @@ def step_impl(context):
 
 
 @when('the draft is sent')
-def step_impl(context):
+def step_impl_draft_is_sent(context):
     context.response = app.test_client().post(url, data=json.dumps(context.message), headers=headers)
 
 
 # Scenario 3: Submit a message with a missing "To" field and receive a 400 error
 @given("the 'To' field is empty")
-def step_impl(context):
+def step_impl_to_field_empty(context):
     data['urn_to'] = ''
 
 
 # Scenario 4: Submit a message with a missing "From" field and receive a 400 error
 @given("the 'From' field is empty")
-def step_impl(context):
+def step_impl_from_field_empty(context):
     data['urn_from'] = ''
 
 
 # Scenario 5: Submit a message with a missing "Body" field and receive a 400 error
 @given("the 'Body' field is empty")
-def step_impl(context):
+def step_impl_body_field_empty(context):
     data['body'] = ''
 
 
 # Scenario 6: Submit a message with a missing "Subject" field and receive a 400
 @given("the 'Subject' field is empty")
-def step_impl(context):
+def step_impl_subject_field_empty(context):
     data['subject'] = ""
 
 
 # Scenario 7: Message sent without a thread id
 @given("the 'Thread ID' field is empty")
-def step_impl(context):
+def step_impl_thread_id_field_empty(context):
     before_scenario(context)
     data['thread_id'] = ''
 
 
 # Scenario 8: Message sent with a urn_to too long
 @given("the 'To' field exceeds max limit in size")
-def step_impl(context):
+def step_impl_to_field_exceeds_max_limit(context):
     data['urn_to'] = "x" * (constants.MAX_TO_LEN+1)
 
 
 # Scenario 9: Message sent with a urn_from too long
 @given("the 'From' field exceeds max limit in size")
-def step_impl(context):
+def step_impl_from_field_exceeds_max_limit(context):
     data['urn_from'] = "y" * (constants.MAX_FROM_LEN+1)
 
 
 # Scenario 10: Message sent with an empty survey field return 400
 @given('the survey field is empty')
-def step_impl(context):
+def step_impl_survey_field_empty(context):
     data['survey'] = ''
 
 
 # Scenario 11: Message sent with a msg_id not a valid draft returns 400
 @given('a message contains a msg_id and is not a valid draft')
-def step_impl(context):
+def step_impl_message_contains_msg_id_and_is_not_valid_draft(context):
     data.update({'msg_id': 'test123',
                  'urn_to': 'test',
                  'urn_from': 'respondent.test',
@@ -148,7 +148,7 @@ def step_impl(context):
 
 # Scenario 12: When a message with the label of "Draft" is sent and another user is trying to send the same message return a 409
 @given('a draft message is posted')
-def step_impl(context):
+def step_impl_draft_message_posted(context):
     if 'msg_id' in data:
         del data['msg_id']
 
@@ -174,7 +174,7 @@ def step_impl(context):
 
 
 @when('another user tries to send the same message')
-def step_impl(context):
+def step_impl_another_user_sends_same_message(context):
     data.update({'msg_id': context.msg_id,
                  'urn_to': 'internal.000000',
                  'urn_from': 'respondent.000000',
@@ -193,13 +193,13 @@ def step_impl(context):
 
 
 @then('is shown a 409 error status')
-def step_impl(context):
+def step_impl_is_shown_404(context):
     nose.tools.assert_equal(context.response.status_code, 409)
 
 
 # Scenario 13:  Scenario: A Etag is not present within the header
 @given('a message is created')
-def step_impl(context):
+def step_impl_message_is_created(context):
     context.msg = {  'urn_to': 'test',
                      'urn_from': 'test',
                      'subject': 'test',
@@ -212,7 +212,7 @@ def step_impl(context):
 
 
 @when('the message is sent with no Etag')
-def step_impl(context):
+def step_impl_message_sent_no_etag(context):
     if 'ETag' in headers:
         del headers['ETag']
 
@@ -223,27 +223,27 @@ def step_impl(context):
 
 
 @when("the message is sent")
-def step_impl(context):
+def step_implmessage_is_sent(context):
     context.response = app.test_client().post(url, data=json.dumps(data), headers=headers)
 
 
 @then('a msg_id in the response')
-def step_impl(context):
+def step_impl_msg_id_in_response(context):
     resp = json.loads(context.response.data)
     nose.tools.assert_true(resp['msg_id'] is not None)
 
 
 @then('a thread_id in the response')
-def step_impl(context):
+def step_impl_thread_id_in_response(context):
     resp = json.loads(context.response.data)
     nose.tools.assert_true(resp['thread_id'] is not None)
 
 
 @then("a 400 error status is returned")
-def step_impl(context):
+def step_impl_400_returned(context):
     nose.tools.assert_equal(context.response.status_code, 400)
 
 
 @then('a 201 status code is the response')
-def step_impl(context):
+def step_impl_201_returned(context):
     nose.tools.assert_equal(context.response.status_code, 201)

--- a/tests/behavioural/features/steps/message_put.py
+++ b/tests/behavioural/features/steps/message_put.py
@@ -59,7 +59,7 @@ def step_impl(context):
 
 
 @when("the message is archived")
-def step_impl(context):
+def step_impl_message_is_archived(context):
     modify_data['action'] = 'add'
     modify_data['label'] = 'ARCHIVE'
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -67,7 +67,7 @@ def step_impl(context):
 
 
 @then('check message is marked as archived')
-def step_impl(context):
+def step_impl_assert_message_is_marked_as_archived(context):
     context.response = app.test_client().get("http://localhost:5050/message/{}".format(context.msg_id),
                                              data=flask.json.dumps(modify_data), headers=headers)
     response = flask.json.loads(context.response.data)
@@ -76,7 +76,7 @@ def step_impl(context):
 
 # Scenario: deleting the "archived" label from a given message
 @given("the message is archived")
-def step_impl(context):
+def step_impl_the_message_is_archived(context):
     reset_db()
     data['urn_to'] = 'internal.12344'
     data['urn_from'] = 'respondent.122342'
@@ -92,7 +92,7 @@ def step_impl(context):
 
 
 @when("the message is unarchived")
-def step_impl(context):
+def step_impl_message_is_unarchived(context):
     modify_data['action'] = 'remove'
     modify_data['label'] = "ARCHIVE"
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -100,7 +100,7 @@ def step_impl(context):
 
 
 @then('check message is not marked as archived')
-def step_impl(context):
+def step_impl_message_not_marked_archived(context):
     context.response = app.test_client().get("http://localhost:5050/message/{}".format(context.msg_id),
                                              data=flask.json.dumps(modify_data), headers=headers)
     response = flask.json.loads(context.response.data)
@@ -109,7 +109,7 @@ def step_impl(context):
 
 # Scenario: Modifying the status of the message to "unread"
 @given('a message has been read')
-def step_impl(context):
+def step_impl_message_has_been_read(context):
     reset_db()
     data['urn_to'] = 'internal.12344'
     data['urn_from'] = 'respondent.122342'
@@ -125,7 +125,7 @@ def step_impl(context):
 
 
 @when("the message is marked unread")
-def step_impl(context):
+def step_impl_message_marked_unread(context):
     modify_data['action'] = 'add'
     modify_data['label'] = "UNREAD"
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -133,7 +133,7 @@ def step_impl(context):
 
 
 @then('check message is marked unread')
-def step_impl(context):
+def step_imp_check_message_is_marked_unread(context):
     context.response = app.test_client().get("http://localhost:5050/message/{}".format(context.msg_id),
                                              data=flask.json.dumps(modify_data), headers=headers)
     response = flask.json.loads(context.response.data)
@@ -144,7 +144,7 @@ def step_impl(context):
 
 
 @when("the message is marked read")
-def step_impl(context):
+def step_impl_the_message_is_marked_read(context):
     modify_data['action'] = 'remove'
     modify_data['label'] = "UNREAD"
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -152,7 +152,7 @@ def step_impl(context):
 
 
 @then('check message is not marked unread')
-def step_impl(context):
+def step_impl_check_message_is_not_marked_unread(context):
     context.response = app.test_client().get("http://localhost:5050/message/{}".format(context.msg_id),
                                              data=flask.json.dumps(modify_data), headers=headers)
     response = flask.json.loads(context.response.data)
@@ -160,14 +160,14 @@ def step_impl(context):
 
 
 @then('message read date should be set')
-def step_impl(context):
+def step_impl_message_read_date_should_be_set(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_is_not_none(response['read_date'])
 
 
 # Scenario: validating a request where there is no label provided
 @given('a message is sent')
-def step_impl(context):
+def step_impl_a_message_is_sent(context):
     reset_db()
     data['urn_to'] = 'internal.12344'
     data['urn_from'] = 'respondent.122342'
@@ -178,7 +178,7 @@ def step_impl(context):
 
 
 @when('the label is empty')
-def step_impl(context):
+def step_impl_the_label_is_empty(context):
     modify_data['action'] = 'add'
     modify_data['label'] = ''
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -186,14 +186,14 @@ def step_impl(context):
 
 
 @then('a Bad Request error is returned')
-def step_impl(context):
+def step_impl_a_bad_request_is_returned(context):
     nose.tools.assert_equal(context.response.status_code, 400)
 
 
 #  Scenario: validating a request where there is no action provided
 
 @when('the action is empty')
-def step_impl(context):
+def step_impl_the_action_is_empty(context):
     modify_data['action'] = ''
     modify_data['label'] = 'SENT'
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -201,14 +201,14 @@ def step_impl(context):
 
 
 @then('a Bad Request 400 error is returned')
-def step_impl(context):
+def step_impl_a_bad_request_400_is_returned(context):
     nose.tools.assert_equal(context.response.status_code, 400)
 
 
 # Scenario: validating a request where there in an invalid label provided
 
 @when('an invalid label is provided')
-def step_impl(context):
+def step_impl_an_invalid_label_is_provided(context):
     modify_data['action'] = ''
     modify_data['label'] = 'DELETED'
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -216,13 +216,13 @@ def step_impl(context):
 
 
 @then('display a Bad Request is returned')
-def step_impl(context):
+def step_impl_display_a_bad_request_is_returned(context):
     nose.tools.assert_equal(context.response.status_code, 400)
 
 
 #  Scenario: validating a request where there in an invalid action provided
 @when('an invalid action is provided')
-def step_impl(context):
+def step_impl_an_invalid_action_is_provided(context):
     modify_data['action'] = ''
     modify_data['label'] = 'ARCHIVE'
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -230,13 +230,13 @@ def step_impl(context):
 
 
 @then('show a Bad Request is returned')
-def step_impl(context):
+def step_impl_a_bad_request_is_returned(context):
     nose.tools.assert_equal(context.response.status_code, 400)
 
 
 #  Scenario: validating a request where there in an unmodifiable label is provided
 @when('an unmmodifiable label is provided')
-def step_impl(context):
+def step_impl_an_unmodifiable_label_is_provided(context):
     modify_data['action'] = ''
     modify_data['label'] = 'UNREAD'
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -244,20 +244,20 @@ def step_impl(context):
 
 
 @then('a Bad Request is displayed to the user')
-def step_impl(context):
+def step_impl_a_bad_request_is_displayed(context):
     nose.tools.assert_equal(context.response.status_code, 400)
 
 
 # Scenario - internal - message status automatically changes to read - on opening message
 @given("a message with the status 'unread' is shown to an internal user")
-def step_impl(context):
+def step_impl_message_with_status_unread_shown_to_the_user(context):
     response = app.test_client().post("http://localhost:5050/message/send", data=json.dumps(data), headers=headers)
     resp_data = json.loads(response.data)
     context.msg_id = resp_data['msg_id']
 
 
 @when("the internal user opens the message")
-def step_impl(context):
+def step_impl_an_internal_user_opens_the_message(context):
     token_data['user_urn'] = data['urn_from']
     headers['Authorization'] = update_encrypted_jwt()
     response_get = app.test_client().get("http://localhost:5050/message/{0}".format(context.msg_id), headers=headers)
@@ -265,13 +265,13 @@ def step_impl(context):
 
 
 @then("the status of the message changes from 'unread' to 'read' for all internal users that have access to that survey")
-def step_impl(context):
+def step_impl_no_unread_messages_returned(context):
     nose.tools.assert_true("UNREAD" not in context.get_json['labels'])
 
 
 # Scenario - internal - as an internal user I want to be able to change my message from read to unread
 @given("a message with the status read is displayed to an internal user")
-def step_impl(context):
+def step_impl_message_with_status_read_returned(context):
     reset_db()
     data['urn_to'] = 'internal.12344'
     data['urn_from'] = 'respondent.122342'
@@ -287,7 +287,7 @@ def step_impl(context):
 
 
 @when("the internal user chooses to edit the status from read to unread")
-def step_impl(context):
+def step_impl_edit_status_read_to_unread(context):
     modify_data['action'] = 'add'
     modify_data['label'] = "UNREAD"
     context.response = app.test_client().put(url.format(context.msg_id),
@@ -295,7 +295,7 @@ def step_impl(context):
 
 
 @then("the status of that message changes to unread for all internal users that have access to that survey")
-def step_impl(context):
+def step_impl_status_of_message_changes_to_unread(context):
     context.response = app.test_client().get("http://localhost:5050/message/{}".format(context.msg_id),
                                              data=flask.json.dumps(modify_data), headers=headers)
     response = flask.json.loads(context.response.data)
@@ -303,21 +303,21 @@ def step_impl(context):
 
 
 @given("a message with the status unread is displayed to an internal user")
-def step_impl(context):
+def step_impl_message_status_unread_returned(context):
     response = app.test_client().post("http://localhost:5050/message/send", data=json.dumps(data), headers=headers)
     resp_data = json.loads(response.data)
     context.msg_id = resp_data['msg_id']
 
 
 @when("the internal user chooses to edit the status from unread to read")
-def step_impl(context):
+def step_impledit_status_from_unread_to_read(context):
     modify_data['action'] = 'remove'
     modify_data['label'] = 'UNREAD'
     app.test_client().put(url.format(context.msg_id), data=flask.json.dumps(modify_data), headers=headers)
 
 
 @then("the status of that message changes to read for all internal users that have access to that survey")
-def step_impl(context):
+def step_impl_message_status_chanegs_to_read(context):
     request = app.test_client().get("http://localhost:5050/message/{0}".format(context.msg_id), headers=headers)
     request_data = json.loads(request.data)
     nose.tools.assert_true("UNREAD" not in request_data['labels'])
@@ -325,26 +325,26 @@ def step_impl(context):
 
 # Scenario: As an external user - message status automatically changes to read - on opening message
 @given("a message with the status 'unread' is shown to an external user")
-def step_impl(context):
+def step_impl_message_status_unread_returned(context):
     response = app.test_client().post("http://localhost:5050/message/send", data=json.dumps(data), headers=headers)
     resp_data = json.loads(response.data)
     context.msg_id = resp_data['msg_id']
 
 
 @when("the external user opens the message")
-def step_impl(context):
+def step_impl_external_user_opens_the_message(context):
     request = app.test_client().get("http://localhost:5050/message/{0}".format(context.msg_id), headers=headers)
     context.request_data = json.loads(request.data)
 
 
 @then("the status of the message changes to from unread to read")
-def step_impl(context):
+def step_impl_message_statis_changes_from_unread_to_read(context):
     nose.tools.assert_true("UNREAD" not in context.request_data['labels'])
 
 
 # Scenario - external - as an external user I want to be able to change my message from read to unread
 @given("a message with the status read is displayed to an external user")
-def step_impl(context):
+def step_implmessage_with_status_read_returned(context):
     response = app.test_client().post("http://localhost:5050/message/send", data=json.dumps(data), headers=headers)
     resp_data = json.loads(response.data)
     context.msg_id = resp_data['msg_id']
@@ -354,35 +354,35 @@ def step_impl(context):
 
 
 @when("the external user chooses to edit the status from read to unread")
-def step_impl(context):
+def step_impl_external_user_edits_status_from_read_to_unread(context):
     modify_data['action'] = 'add'
     modify_data['label'] = 'UNREAD'
     app.test_client().put(url.format(context.msg_id), data=flask.json.dumps(modify_data), headers=headers)
 
 
 @then("the status of that message changes to unread")
-def step_impl(context):
+def step_impl_the_status_of_the_message_changes_to_unread(context):
     request = app.test_client().get("http://localhost:5050/message/{0}".format(context.msg_id), headers=headers)
     request_data = json.loads(request.data)
     nose.tools.assert_true("UNREAD" in request_data['labels'])
 
 
 @given("a message with the status unread is displayed to an external user")
-def step_impl(context):
+def step_impl_message_with_Status_unread_returned(context):
     response = app.test_client().post("http://localhost:5050/message/send", data=json.dumps(data), headers=headers)
     resp_data = json.loads(response.data)
     context.msg_id = resp_data['msg_id']
 
 
 @when("the external user chooses to edit the status from unread to read")
-def step_impl(context):
+def step_impl_edit_status_from_unread_to_read(context):
     modify_data['action'] = 'remove'
     modify_data['label'] = 'UNREAD'
     app.test_client().put(url.format(context.msg_id), data=flask.json.dumps(modify_data), headers=headers)
 
 
 @then("the status of that message changes to read")
-def step_impl(context):
+def step_impl_assert_message_status_changes_to_read(context):
     request = app.test_client().get("http://localhost:5050/message/{0}".format(context.msg_id), headers=headers)
     request_data = json.loads(request.data)
     nose.tools.assert_true("UNREAD" not in request_data['labels'])
@@ -390,16 +390,16 @@ def step_impl(context):
 
 # If an incorrect message id is requested by the user return a 400 error
 @given("a user requests a message with a invalid message id")
-def step_impl(context):
+def step_impl_return_message_with_invalid_msg_id(context):
     context.msg_id = "MsgIdExceedsMsgIdLengthsdhkbgjksdlfknbsjdshbfjskgbhdhdghgdhdfsdhjghbskggdh"
 
 
 @when("it is searched for and not a valid message id")
-def step_impl(context):
+def step_impl_searched_for_and_not_valid_message_id(context):
     context.response = app.test_client().put("http://localhost:5050/message/{0}".format(context.msg_id),
                                              data=json.dumps(data), headers=headers)
 
 
 @then("a 400 error code is returned to the user")
-def step_impl(context):
+def step_impl_400_returned(context):
     nose.tools.assert_equal(context.response.status_code, 400)

--- a/tests/behavioural/features/steps/messages_get.py
+++ b/tests/behavioural/features/steps/messages_get.py
@@ -46,7 +46,7 @@ def reset_db():
 
 
 @given("a respondent sends multiple messages")
-def step_impl(context):
+def step_impl_respondent_sends_multiple_messages(context):
     reset_db()
     for x in range(0, 2):
         data['urn_to'] = 'internal.12344'
@@ -56,14 +56,14 @@ def step_impl(context):
 
 
 @when("the respondent gets their messages")
-def step_impl(context):
+def step_impl_respondent_gets_their_messages(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url, headers=headers)
 
 
 @then("the retrieved messages should have the correct SENT labels")
-def step_impl(context):
+def step_impl_retrieved_messages_should_have_sent_labels(context):
     response = flask.json.loads(context.response.data)
     for x in range(0, len(response['messages'])):
         nose.tools.assert_equal(response['messages'][x]['labels'], ['SENT'])
@@ -72,7 +72,7 @@ def step_impl(context):
 # Scenario: Internal user sends multiple messages and retrieves the list of messages with their labels
 
 @given("a Internal user sends multiple messages")
-def step_impl(context):
+def step_impl_internal_user_sends_multiple_messages(context):
     reset_db()
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
@@ -82,7 +82,7 @@ def step_impl(context):
 
 
 @when("the Internal user gets their messages")
-def step_impl(context):
+def step_impl_internal_user_gets_their_messages(context):
     token_data['user_urn'] = 'internal.122342'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url, headers=headers)
@@ -92,7 +92,7 @@ def step_impl(context):
 
 
 @then("the retrieved messages should have the correct INBOX and UNREAD labels")
-def step_impl(context):
+def step_impl_message_should_have_correct_inbox_and_unread_labels(context):
     response = flask.json.loads(context.response.data)
     for x in range(0, len(response['messages'])):
         # num = x+1
@@ -106,21 +106,21 @@ def step_impl(context):
 
 
 @given("multiple messages have been sent to an external user")
-def step_impl(context):
+def step_implmultiple_messages_sent_to_external_user(context):
     for x in range(0, 2):
         data['urn_to'] = 'respondent.123'
         app.test_client().post("http://localhost:5050/message/send", headers=headers)
 
 
 @when("the external user navigates to their messages")
-def step_impl(context):
+def step_impl_external_user_navigates_to_their_messages(context):
     token_data['user_urn'] = 'respondent.123'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url, headers=headers)
 
 
 @then("messages are displayed")
-def step_impl(context):
+def step_impl_messages_are_displayed(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_true(len(response['messages']), 2)
 
@@ -128,7 +128,7 @@ def step_impl(context):
 
 
 @given('a respondent and an Internal user sends multiple messages')
-def step_impl(context):
+def step_impl_respondant_and_internal_user_send_multiple_messages(context):
     reset_db()
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
@@ -143,14 +143,14 @@ def step_impl(context):
 
 
 @when('the Respondent gets their sent messages')
-def step_impl(context):
+def step_impl_respondent_gets_their_sent_messages(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?label=SENT'), headers=headers)
 
 
 @then('the retrieved messages should all have sent labels')
-def step_impl(context):
+def step_impl_the_retrieved_messaages_all_have_sent_labels(context):
     response = flask.json.loads(context.response.data)
     for x in range(1, len(response['messages'])):
         nose.tools.assert_equal(response['messages'][x]['labels'], ['SENT'])
@@ -161,7 +161,7 @@ def step_impl(context):
 
 
 @given('a Internal user sends multiple messages with different reporting unit')
-def step_impl(context):
+def step_impl_internal_user_sends_multiple_messages_with_different_ru(context):
     reset_db()
 
     for x in range(0, 2):
@@ -178,14 +178,14 @@ def step_impl(context):
 
 
 @when('the Respondent gets their messages with particular reporting unit')
-def step_impl(context):
+def step_impl_respondent_gets_their_messages_with_particular_ru(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?ru=AnotherReportingUnit'), headers=headers)
 
 
 @then('the retrieved messages should have the correct reporting unit')
-def step_impl(context):
+def step_impl_assert_correct_ru(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_equal(response['messages'][1]['reporting_unit'], 'AnotherReportingUnit')
     nose.tools.assert_equal(len(response['messages']), 2)
@@ -194,7 +194,7 @@ def step_impl(context):
 # Scenario: Respondent and internal user sends multiple messages and Respondent retrieves the list of messages with business name
 
 @given('an Internal user sends multiple messages with different business names')
-def step_impl(context):
+def step_impl_respondent_retrieves_list_of_messages_with_busines_name(context):
     reset_db()
 
     for x in range(0, 2):
@@ -211,14 +211,14 @@ def step_impl(context):
 
 
 @when('the Respondent gets their messages with particular business name')
-def step_impl(context):
+def step_impl_respondent_retrieves_messages_with_particular_business_name(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?business=AnotherBusiness'), headers=headers)
 
 
 @then('the retrieved messages should have the correct business name')
-def step_impl(context):
+def step_impl_assert_messages_have_correct_business_name(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -229,7 +229,7 @@ def step_impl(context):
 # Scenario: Internal user sends multiple messages and Respondent retrieves the list of messages with particular survey
 
 @given('a Internal user sends multiple messages with different survey')
-def step_impl(context):
+def step_impl_internal_user_sends_multiple_messages_with_different_survey(context):
     reset_db()
 
     for x in range(0, 2):
@@ -246,14 +246,14 @@ def step_impl(context):
 
 
 @when('the Respondent gets their messages with particular survey')
-def step_impl(context):
+def step_impl_respondent_gets_their_messages_with_particular_survey(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?survey=AnotherSurvey'), headers=headers)
 
 
 @then('the retrieved messages should have the correct survey')
-def step_impl(context):
+def step_impl_retrieved_messages_shoud_have_correct_survey(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_equal(response['messages'][1]['survey'], 'AnotherSurvey')
 
@@ -264,7 +264,7 @@ def step_impl(context):
 
 
 @given('a Internal user sends multiple messages with different collection case')
-def step_impl(context):
+def step_impl_internal_user_sends_multiple_messages_with_different_collection_case(context):
     reset_db()
 
     for x in range(0, 2):
@@ -281,14 +281,14 @@ def step_impl(context):
 
 
 @when('the Respondent gets their messages with particular collection case')
-def step_impl(context):
+def step_impl_respondent_retrieves_messaegs_with_particular_collection_case(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?cc=AnotherCollectionCase'), headers=headers)
 
 
 @then('the retrieved messages should have the correct collection case')
-def step_impl(context):
+def step_impl_assert_messages_have_correct_collection_case(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_equal(response['messages'][1]['collection_case'], 'AnotherCollectionCase')
 
@@ -299,7 +299,7 @@ def step_impl(context):
 
 
 @given('a Respondent creates multiple draft messages')
-def step_impl(context):
+def step_impl_respondent_creates_multiple_draft_messages(context):
     reset_db()
 
     for x in range(0, 2):
@@ -322,7 +322,7 @@ def step_impl(context):
 
 
 @then('the retrieved messages should all have draft labels')
-def step_impl(context):
+def step_impl_assert_all_messages_have_draft_labels(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_equal(response['messages'][1]['labels'], ['DRAFT'])
 
@@ -332,7 +332,7 @@ def step_impl(context):
 
 
 @then('the retrieved messages should not have DRAFT_INBOX labels')
-def step_impl(context):
+def step_impl_assert_no_message_has_draft_inbox_label(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -342,7 +342,7 @@ def step_impl(context):
 
 # Scenario: As an external user I would like to be able to view a list of messages
 @given("an external user has multiple messages")
-def step_impl(context):
+def step_impl_external_user_has_multiple_messages(context):
     reset_db()
     token_data['user_urn'] = 'respondent.123'
     headers['Authorization'] = update_encrypted_jwt()
@@ -353,19 +353,19 @@ def step_impl(context):
 
 
 @when("the external user requests all messages")
-def step_impl(context):
+def step_impl_external_user_requests_all_messages(context):
     request = app.test_client().get(url, headers=headers)
     context.response = flask.json.loads(request.data)
 
 
 @then("all external users messages are returned")
-def step_impl(context):
+def step_impl_assert_correct_number_of_messages_returned(context):
     nose.tools.assert_equal(len(context.response['messages']), 4)
 
 
 # Scenario: As a user I would like to be able to view a list of inbox messages
 @given("a internal user receives multiple messages")
-def step_impl(context):
+def step_impl_internal_user_receives_multiple_messages(context):
     reset_db()
     for x in range(0, 2):
         data['urn_to'] = 'respondent.123'
@@ -375,14 +375,14 @@ def step_impl(context):
 
 
 @when("the internal user gets their inbox messages")
-def step_impl(context):
+def step_impl_internal_user_gets_their_inbox_messages(context):
     token_data['user_urn'] = 'respondent.123'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?label=INBOX'), headers=headers)
 
 
 @then("the retrieved messages should all have inbox labels")
-def step_impl(context):
+def step_impl_assert_all_messages_have_inbox_and_unread_labels(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_equal(response['messages'][1]['labels'], ['INBOX', 'UNREAD'])
 
@@ -392,37 +392,37 @@ def step_impl(context):
 
 
 @given('parameter limit has value string')
-def step_impl(context):
+def step_impl_parameter_limit_has_string_value(context):
     context.parms = "?limit=string"
 
 
 @given('parameter page has value string')
-def step_impl(context):
+def step_impl_parameter_page_has_string_value(context):
     context.parms = "?page=string"
 
 
 @given('parameter survey has value NotASurvey')
-def step_impl(context):
+def step_impl_parameter_survey_is_not_a_survey(context):
     context.parms = "?survey=NotASurvey"
 
 
 @given('parameter labels has value NotALabel')
-def step_impl(context):
+def step_impl_parameter_label_has_value_not_a_label(context):
     context.parms = "?labels=NotALabel"
 
 
 @given('parameter reportingUnit has value LongerThan11Chars')
-def step_impl(context):
+def step_implreporting_unit_equals_longer_than_1_character(context):
     context.parms = "?reportingUnit=LongerThan11Chars"
 
 
 @given('parameter labels has value INBOX-SENT-ARCHIVED-DRAFT-INBOX-SENT-ARCHIVED-DRAFT')
-def step_impl(context):
+def step_impl_labels_param_set_to_include_all(context):
     context.parms = "?labels=INBOX-SENT-ARCHIVED-DRAFT-INBOX-SENT-ARCHIVED-DRAFT"
 
 
 @when('user gets messages using the parameters')
-def step_impl(context):
+def step_impl_get_messages_using_params(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     url_with_param = "{0}{1}".format(url, context.parms)
@@ -430,13 +430,13 @@ def step_impl(context):
 
 
 @then("a 400 HTTP bad syntax response is returned")
-def step_impl(context):
+def step_impl_return_400(context):
     nose.tools.assert_equal(context.response.status_code, 400)
 
 
 #   Scenario Outline: User gets messages with various labels options
 @given('there are multiple messages to retrieve for all labels')
-def step_impl(context):
+def step_impl_multiple_messages_for_all_labels(context):
     reset_db()
 
     for _ in range(0, 2):
@@ -453,7 +453,7 @@ def step_impl(context):
 
 
 @when('respondent gets messages with labels INBOX')
-def step_impl(context):
+def step_impl_reponsdent_gets_message_with_label_inbox(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     parms = "?labels=INBOX"
@@ -462,7 +462,7 @@ def step_impl(context):
 
 
 @when('respondent gets messages with labels SENT')
-def step_impl(context):
+def step_impl_respondent_gets_messages_with_label_sent(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     parms = "?labels=SENT"
@@ -471,7 +471,7 @@ def step_impl(context):
 
 
 @when('respondent gets messages with labels ARCHIVED')
-def step_impl(context):
+def step_impl_respondent_gets_messaegs_with_label_archived(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     parms = "?labels=ARCHIVED"
@@ -480,7 +480,7 @@ def step_impl(context):
 
 
 @when('respondent gets messages with labels DRAFT')
-def step_impl(context):
+def step_impl_respondent_gets_messages_with_label_draft(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     parms = "?labels=DRAFT"
@@ -489,7 +489,7 @@ def step_impl(context):
 
 
 @when('respondent gets messages with labels INBOX-SENT')
-def step_impl(context):
+def step_impl_respondent_gets_messages_with_labels_inbox_sent(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     parms = "?labels=INBOX-SENT"
@@ -498,7 +498,7 @@ def step_impl(context):
 
 
 @when('respondent gets messages with labels INBOX-SENT-ARCHIVED')
-def step_impl(context):
+def step_impl_respondent_gets_messages_with_labels_inbox_sent_archived(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     parms = "?labels=INBOX-SENT-ARCHIVED"
@@ -507,7 +507,7 @@ def step_impl(context):
 
 
 @when('respondent gets messages with labels INBOX-SENT-ARCHIVED-DRAFT')
-def step_impl(context):
+def step_impl_respondent_gets_messages_with_labels_inbox_sent_archived_draft(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     parms = "?labels=INBOX-SENT-ARCHIVED-DRAFT"
@@ -516,7 +516,7 @@ def step_impl(context):
 
 
 @then('messages returned should have one of the labels INBOX')
-def step_impl(context):
+def step_impl_assert_one_message_has_inbox_label(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -524,7 +524,7 @@ def step_impl(context):
 
 
 @then('messages returned should have one of the labels SENT')
-def step_impl(context):
+def step_impl_assert_one_message_has_label_sent(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -532,7 +532,7 @@ def step_impl(context):
 
 
 @then('messages returned should have one of the labels ARCHIVED')
-def step_impl(context):
+def step_impl_assert_one_message_has_label_archived(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -540,7 +540,7 @@ def step_impl(context):
 
 
 @then('messages returned should have one of the labels DRAFT')
-def step_impl(context):
+def step_impl_assert_one_message_has_label_draft(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -548,7 +548,7 @@ def step_impl(context):
 
 
 @then('messages returned should have one of the labels INBOX-SENT')
-def step_impl(context):
+def step_impl_assert_one_message_has_label_inbox_sent(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -557,7 +557,7 @@ def step_impl(context):
 
 
 @then('messages returned should have one of the labels INBOX-SENT-ARCHIVED')
-def step_impl(context):
+def step_impl_assert_one_message_has_label_sent_archived(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -567,7 +567,7 @@ def step_impl(context):
 
 
 @then('respondent gets messages with labels INBOX-SENT-ARCHIVED-DRAFT')
-def step_impl(context):
+def step_impl_assert_one_message_has_label_sent_draft(context):
     response = flask.json.loads(context.response.data)
 
     for x in range(1, len(response['messages'])):
@@ -578,7 +578,7 @@ def step_impl(context):
 
 
 @when('respondent gets messages with labels empty')
-def step_impl(context):
+def step_impl_assert_messaegs_with_empty_labels(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     parms = "?labels="
@@ -587,7 +587,7 @@ def step_impl(context):
 
 
 @then('all messages should be returned')
-def step_impl(context):
+def step_impl_assert_all_messages_returned(context):
     response = flask.json.loads(context.response.data)
     # change number to expected number of messages depending on the
     # "there are multiple messages to retrieve for all labels" step
@@ -596,7 +596,7 @@ def step_impl(context):
 
 
 @given("a respondent user receives multiple messages")
-def step_impl(context):
+def step_impl_respondent_recieves_multiple_messages(context):
     reset_db()
     for x in range(0, 2):
         data['urn_to'] = 'respondent.123'
@@ -606,7 +606,7 @@ def step_impl(context):
 
 
 @when("the respondent user gets their inbox messages")
-def step_impl(context):
+def step_impl_assert_respondent_gets_their_inbox_messages(context):
     token_data['user_urn'] = 'respondent.123'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?label=INBOX'), headers=headers)

--- a/tests/behavioural/features/steps/request_check.py
+++ b/tests/behavioural/features/steps/request_check.py
@@ -26,14 +26,14 @@ headers['Authorization'] = update_encrypted_jwt()
 
 
 @given("no user urn is in the header")
-def step_impl(context):
+def step_impl_no_user_urn_in_the_header(context):
     if 'user_urn' in token_data:
         del token_data['user_urn']
         headers['Authorization'] = update_encrypted_jwt()
 
 
 @when("a GET request is made")
-def step_impl(context):
+def step_impl_get_request_is_made(context):
     url = "http://localhost:5050/message/1"
     context.response = app.test_client().get(url, headers=headers)
 
@@ -42,7 +42,7 @@ def step_impl(context):
 
 
 @when("a POST request is made")
-def step_impl(context):
+def step_impl_post_request_is_made(context):
     url = "http://localhost:5050/message/send"
     context.response = app.test_client().post(url, headers=headers)
 
@@ -50,7 +50,7 @@ def step_impl(context):
 
 
 @when("a PUT request is made")
-def step_impl(context):
+def step_impl_put_request_is_made(context):
     url = "http://localhost:5050/message/1/modify"
     context.response = app.test_client().put(url, headers=headers)
 
@@ -58,60 +58,60 @@ def step_impl(context):
 
 
 @given("user wants to use /draft/save endpoint")
-def step_impl(context):
+def step_impl_use_draft_save_endpoint(context):
     context.url = "http://localhost:5050/draft/save"
 
 
 @given("user wants to use /health endpoint")
-def step_impl(context):
+def step_impl_use_health_endpoint(context):
     context.url = "http://localhost:5050/health"
 
 
 @given("user wants to use /health/db endpoint")
-def step_impl(context):
+def step_impl_use_health_db_endpoint(context):
     context.url = "http://localhost:5050/health/db"
 
 
 @given("user wants to use /health/details endpoint")
-def step_impl(context):
+def step_impl_use_health_details_endpoint(context):
     context.url = "http://localhost:5050/health/details"
 
 
 @given("user wants to use /message/id endpoint")
-def step_impl(context):
+def step_impl_use_message_id_endpoint(context):
     context.url = "http://localhost:5050/message/1"
 
 
 @given("user wants to use /message/id/modify endpoint")
-def step_impl(context):
+def step_impl_use_message_id_modify_endpoint(context):
     context.url = "http://localhost:5050/message/1/modify"
 
 
 @given("user wants to use /message/send endpoint")
-def step_impl(context):
+def step_impl_use_message_send_endpoint(context):
     context.url = "http://localhost:5050/message/send"
 
 
 @given("user wants to use /messages endpoint")
-def step_impl(context):
+def step_impl_use_messages_endpoint(context):
     context.url = "http://localhost:5050/messages"
 
 
 @when("user tries to access that endpoint with the POST method")
-def step_impl(context):
+def step_impl_access_endpoint_withpost(context):
     context.response = app.test_client().post(context.url, headers=headers)
 
 
 @when("user tries to access that endpoint with the GET method")
-def step_impl(context):
+def step_impl_aaacess_endpoint_with_get(context):
     context.response = app.test_client().get(context.url, headers=headers)
 
 
 @when("user tries to access that endpoint with the PUT method")
-def step_impl(context):
+def step_impl_access_endpoint_with_put(context):
     context.response = app.test_client().put(context.url, headers=headers)
 
 
 @then("a 405 error status is returned")
-def step_impl(context):
+def step_impl_assert_405_returned(context):
     nose.tools.assert_equal(context.response.status_code, 405)

--- a/tests/behavioural/features/steps/thread_get.py
+++ b/tests/behavioural/features/steps/thread_get.py
@@ -47,7 +47,7 @@ def reset_db():
 
 
 @given("a respondent and internal user have a conversation")
-def step_impl(context):
+def step_impl_respondent_and_internal_user_hav_a_conversation(context):
     reset_db()
 
     data['thread_id'] = 'AConversation'
@@ -63,14 +63,14 @@ def step_impl(context):
 
 
 @when("the respondent gets this conversation")
-def step_impl(context):
+def step_impl_respondent_gets_conversation(context):
     token_data['user_urn'] = 'respondent.122342'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url.format(data['thread_id']), headers=headers)
 
 
 @then("all messages from that conversation should be received")
-def step_impl(context):
+def step_impl_assert_all_messages_in_conversation_are_received(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_equal(len(response), 4)
 
@@ -78,7 +78,7 @@ def step_impl(context):
 #   Scenario: Respondent and internal user have a conversation and respondent retrieves the conversation
 
 @when("the internal user gets this conversation")
-def step_impl(context):
+def step_impl_internal_user_gets_conversation(context):
     token_data['user_urn'] = 'internal.12344'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url.format(data['thread_id']), headers=headers)
@@ -87,7 +87,7 @@ def step_impl(context):
 
 
 @given("internal user creates a draft")
-def step_impl(context):
+def step_impl_internal_user_creates_a_draft(context):
         data['urn_to'] = 'respondent.122342'
         data['urn_from'] = 'internal.12344'
         data['thread_id'] = 'AConversation'
@@ -98,14 +98,14 @@ def step_impl(context):
 
 
 @then("all messages from that conversation should be received including draft")
-def step_impl(context):
+def step_impl_assert_all_messages_from_conversation_are_received(context):
     response = flask.json.loads(context.response.data)
     nose.tools.assert_equal(len(response), 5)
 
 
 #   Scenario: Respondent and internal user have a conversation and internal user retrieves that conversation from multiple conversations
 @given("internal user has multiple conversations")
-def step_impl(context):
+def step_impl_internal_user_has_multiple_conversations(context):
 
     for _ in range(0, 2):
         data['thread_id'] = str(uuid.uuid4())
@@ -122,6 +122,6 @@ def step_impl(context):
 
 #   Scenario: User tries to retrieve a conversation that does not exist
 @given("a respondent picks a conversation that does not exist")
-def step_impl(context):
+def step_impl_pick_conversation_that_does_not_exist(context):
     reset_db()
     data['thread_id'] = str(uuid.uuid4())


### PR DESCRIPTION
**What is the context of this PR?**
Codecy is giving errors because it cannot differentiate between multiple implementations of functions with the same name . Behave is ok because it uses the decorators . If we do not do this we are starting to ignore codecy issues so we are more likely to miss more important issues if we do not do this 

Link to Trello card : https://trello.com/c/F29ek6LZ

Describe what you have changed and why, link to other PRs or Issues as appropriate.

Changed the step_impl function names so that the name is close to the decorator string and hence does not clash 

**How to review**

Any notes for the reviewer  (include screenshots if appropriate).
