### PR TITLE
Ts 179 add initial indexes

### DIFF
--- a/app/repository/database.py
+++ b/app/repository/database.py
@@ -30,7 +30,7 @@ class SecureMessage(db.Model):
     survey = Column("survey", String(constants.MAX_SURVEY_LEN+1))
     statuses = relationship('Status', backref='secure_message')
     events = relationship('Events', backref='secure_message', order_by='Events.date_time')
-    Index("idx_ru_survey_cc", "reporting_unit", "survey", "collection_case")
+    __table_args__ = (Index("idx_ru_survey_cc", "reporting_unit", "survey", "collection_case"), )
 
     def __init__(self, msg_id="", subject="", body="", thread_id="", collection_case='',
                  reporting_unit='', survey='', business_name=''):
@@ -112,7 +112,7 @@ class Status(db.Model):
     label = Column('label', String(constants.MAX_STATUS_LABEL_LEN + 1))
     msg_id = Column('msg_id', String(constants.MAX_MSG_ID_LEN + 1), ForeignKey('secure_message.msg_id'))
     actor = Column('actor', String(constants.MAX_STATUS_ACTOR_LEN + 1))
-    Index("idx_msg_id_label", "msg_id", "label")
+    __table_args__ = (Index("idx_msg_id_label", "msg_id", "label"),)
 
     def __init__(self, label='', msg_id='', actor=''):
         self.msg_id = msg_id
@@ -170,7 +170,7 @@ class Events(db.Model):
     event = Column('event', String(constants.MAX_EVENT_LEN + 1))
     msg_id = Column('msg_id', String(constants.MAX_MSG_ID_LEN + 1), ForeignKey('secure_message.msg_id'), index=True)
     date_time = Column('date_time', DateTime())
-    Index("idx_msg_id_event", "msg_id", "event")
+    __table_args__ = (Index("idx_msg_id_event", "msg_id", "event"),)
 
     def __init__(self, date_time=datetime.now(timezone.utc), msg_id='', event=''):
         self.msg_id = msg_id

--- a/app/repository/database.py
+++ b/app/repository/database.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy import Column, String, Integer, DateTime, ForeignKey
+from sqlalchemy import Column, String, Integer, DateTime, ForeignKey, Index
 from sqlalchemy.orm import relationship
 
 from app import constants
@@ -20,16 +20,17 @@ class SecureMessage(db.Model):
     __tablename__ = "secure_message"
 
     id = Column("id", Integer(), primary_key=True)
-    msg_id = Column("msg_id", String(constants.MAX_MSG_ID_LEN), unique=True)
+    msg_id = Column("msg_id", String(constants.MAX_MSG_ID_LEN), unique=True, index=True)
     subject = Column("subject", String(constants.MAX_SUBJECT_LEN+1))
     body = Column("body", String(constants.MAX_BODY_LEN+1))
-    thread_id = Column("thread_id", String(constants.MAX_THREAD_LEN + 1))
+    thread_id = Column("thread_id", String(constants.MAX_THREAD_LEN + 1), index=True)
     collection_case = Column("collection_case", String(constants.MAX_COLLECTION_CASE_LEN+1))
     reporting_unit = Column("reporting_unit", String(constants.MAX_REPORTING_UNIT_LEN+1))
     business_name = Column("business_name", String(constants.MAX_BUSINESS_NAME_LEN + 1))
     survey = Column("survey", String(constants.MAX_SURVEY_LEN+1))
     statuses = relationship('Status', backref='secure_message')
     events = relationship('Events', backref='secure_message', order_by='Events.date_time')
+    Index("idx_ru_survey_cc", "reporting_unit", "survey", "collection_case")
 
     def __init__(self, msg_id="", subject="", body="", thread_id="", collection_case='',
                  reporting_unit='', survey='', business_name=''):
@@ -111,6 +112,7 @@ class Status(db.Model):
     label = Column('label', String(constants.MAX_STATUS_LABEL_LEN + 1))
     msg_id = Column('msg_id', String(constants.MAX_MSG_ID_LEN + 1), ForeignKey('secure_message.msg_id'))
     actor = Column('actor', String(constants.MAX_STATUS_ACTOR_LEN + 1))
+    Index("idx_msg_id_label", "msg_id", "label")
 
     def __init__(self, label='', msg_id='', actor=''):
         self.msg_id = msg_id
@@ -138,7 +140,7 @@ class InternalSentAudit(db.Model):
     __tablename__ = "internal_sent_audit"
 
     id = Column("id", Integer(), primary_key=True)
-    msg_id = Column('msg_id', String(constants.MAX_MSG_ID_LEN + 1), ForeignKey('secure_message.msg_id'))
+    msg_id = Column('msg_id', String(constants.MAX_MSG_ID_LEN + 1), ForeignKey('secure_message.msg_id'), index=True)
     internal_user = Column('internal_user', String(constants.MAX_STATUS_ACTOR_LEN + 1))
 
     def __init__(self, msg_id='', internal_user=''):
@@ -166,8 +168,9 @@ class Events(db.Model):
 
     id = Column('id', Integer(), primary_key=True)
     event = Column('event', String(constants.MAX_EVENT_LEN + 1))
-    msg_id = Column('msg_id', String(constants.MAX_MSG_ID_LEN + 1), ForeignKey('secure_message.msg_id'))
+    msg_id = Column('msg_id', String(constants.MAX_MSG_ID_LEN + 1), ForeignKey('secure_message.msg_id'), index=True)
     date_time = Column('date_time', DateTime())
+    Index("idx_msg_id_event", "msg_id", "event")
 
     def __init__(self, date_time=datetime.now(timezone.utc), msg_id='', event=''):
         self.msg_id = msg_id


### PR DESCRIPTION
**What is the context of this PR?**
We have not defined any indexes apart from the primary index on all the tables . Therefore each query will result in table scans and would hence be slow , but only as the number of messages scales. This ticket is a first pass attempt to create the more obvious indexes on the tables . We should follow this up during the non functional testing to be sure that no table scans take place by using the Postgres tools .

Link to Trello card

https://trello.com/c/RgYPkRj5

Describe what you have changed and why, link to other PRs or Issues as appropriate.

For single column indexes , simply add index=True to the column definitions . Multi column indexes are a little more obtuse to define , and its done by adding a tuple to the __table_args__ variable in the model . 

**How to review**

How to functionally test : 
1) Run up your postgres tool of choice ( I use PgAdmin3) 
2) drop all tables in the SecureMessages db
3) Make sure you have SECURE_MESSAGING_DATABASE_URL defined I used a value of postgresql://localhost/SecureMessages since I dont have any security for my local user , you may have a different local config . You may also need to set SQLALCHEMY_DATABASE_URI to the same value ( we should drop this soon) 
4) Run the app in debugger and validate no errors
5) use PgAdmin ( or your tool of choice) And validate all tables have indexes. 
6) the single column indexes will be 'ix.....' the multi column ones are 'idx....'
