### PR TITLE
Added validation for to and from fields and made subject field required

### DIFF
--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -89,17 +89,17 @@ class MessageSchemaTestCase(unittest.TestCase):
 
     def test_missing_body_fails_validation(self):
         """marshalling message with no body field """
-        message = {'urn_to': 'richard', 'urn_from': 'torrance', 'body': '', 'survey': 'RSI'}
+        message = {'urn_to': 'richard', 'urn_from': 'torrance', 'body': '', 'survey': 'RSI', 'subject': 'MyMessage'}
         schema = MessageSchema()
         errors = schema.load(message)[1]
         self.assertTrue(errors == {'body': ['Body field not populated.']})
 
-    def test_missing_subject_field_does_not_cause_error(self):
+    def test_missing_subject_fails_validation(self):
         """marshalling message with no subject field """
-        message = {'msg_to': 'torrance', 'msg_from': 'someone'}
+        self.json_message.pop('subject', 'MyMessage')
         schema = MessageSchema()
-        errors = schema.load(message)[1]
-        self.assertTrue(errors != {'subject': ['Missing data for required field.']})
+        errors = schema.load(self.json_message)[1]
+        self.assertTrue(errors == {'subject': ['Missing data for required field.']})
 
     def test_subject_field_too_long_causes_error(self):
         """marshalling message with subject field too long"""
@@ -111,10 +111,10 @@ class MessageSchemaTestCase(unittest.TestCase):
 
     def test_missing_thread_field_does_not_cause_error(self):
         """marshalling message with no thread_id field"""
-        message = {'msg_to': 'torrance', 'msg_from': 'someone'}
+        self.json_message.pop('thread_id', "")
         schema = MessageSchema()
-        errors = schema.load(message)[1]
-        self.assertTrue(errors != {'thread_id': ['Missing data for required field.']})
+        errors = schema.load(self.json_message)[1]
+        self.assertTrue(errors == {})
 
     def test_thread_field_too_long_causes_error(self):
         """marshalling message with thread_id field too long"""
@@ -145,6 +145,14 @@ class MessageSchemaTestCase(unittest.TestCase):
         schema = MessageSchema()
         errors = schema.load(self.json_message)[1]
         self.assertTrue(errors == {'survey': ['Survey field not populated.']})
+
+    def test_same_to_from_causes_error(self):
+        """marshalling message with same to and from field"""
+        self.json_message['urn_to'] = self.json_message['urn_from']
+        schema = MessageSchema()
+        errors = schema.load(self.json_message)[1]
+        self.assertTrue(errors == {'_schema': ['urn_to and urn_from fields can not be the same.']})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/behavioural/features/steps/message_post.py
+++ b/tests/behavioural/features/steps/message_post.py
@@ -201,7 +201,7 @@ def step_impl_is_shown_404(context):
 @given('a message is created')
 def step_impl_message_is_created(context):
     context.msg = {  'urn_to': 'test',
-                     'urn_from': 'test',
+                     'urn_from': 'test2',
                      'subject': 'test',
                      'body': 'Test',
                      'thread_id': '',


### PR DESCRIPTION
**What is the context of this PR?**

Link to Trello card
https://trello.com/c/HIOinMzX/305-ts-187-as-a-user-of-thesecure-message-api-an-exception-should-be-thrown-if-i-submit-a-message-post-where-the-to-and-from-fields

Describe what you have changed and why, link to other PRs or Issues as appropriate.
-  Added validation to check to and from fields are not equal
-  Unit test added
-  Fixed BDD test to work with new validation
-  Made 'subject' a required field and changed tests accordingly 

**How to review**

Any notes for the reviewer  (include screenshots if appropriate).
