### PR TITLE
Changes from user_urn to UUIDs and roles added

### DIFF
--- a/app/common/utilities.py
+++ b/app/common/utilities.py
@@ -54,7 +54,7 @@ def add_string_query_args(string_query_args, arg, val):
         return '{0}&{1}={2}'.format(string_query_args, arg, val)
 
 
-def paginated_list_to_json(paginated_list, page, limit, host_url, user_urn, string_query_args,
+def paginated_list_to_json(paginated_list, page, limit, host_url, user, string_query_args,
                            endpoint=MESSAGE_LIST_ENDPOINT):
     """used to change a pagination object to json format with links"""
     messages = []
@@ -65,7 +65,7 @@ def paginated_list_to_json(paginated_list, page, limit, host_url, user_urn, stri
 
     for message in paginated_list.items:
         msg_count += 1
-        msg = message.serialize(user_urn)
+        msg = message.serialize(user)
         msg['_links'] = {"self": {"href": "{0}{1}/{2}".format(host_url, MESSAGE_BY_ID_ENDPOINT, msg['msg_id'])}}
         messages.append(msg)
 

--- a/app/repository/database.py
+++ b/app/repository/database.py
@@ -54,7 +54,7 @@ class SecureMessage(db.Model):
         self.business_name = domain_model.business_name
         self.survey = domain_model.survey
 
-    def serialize(self, user_urn):
+    def serialize(self, user):
         """Return object data in easily serializeable format"""
         message = {
             'urn_to': [],
@@ -74,10 +74,10 @@ class SecureMessage(db.Model):
             'labels': []
         }
 
-        if User(user_urn).is_internal:
+        if user.is_internal:
             actor = self.survey
         else:
-            actor = user_urn
+            actor = user.user_uuid
 
         for row in self.statuses:
             if row.actor == actor:

--- a/app/repository/modifier.py
+++ b/app/repository/modifier.py
@@ -14,9 +14,9 @@ class Modifier:
     """Modifies message to add / remove statuses"""
 
     @staticmethod
-    def add_label(label, message, user_urn):
+    def add_label(label, message, user):
         """add a label to status table"""
-        actor = user_urn if User(user_urn).is_respondent else message['survey']
+        actor = user.user_uuid if user.is_respondent else message['survey']
         try:
             query = "INSERT INTO status (label, msg_id, actor) VALUES ('{0}','{1}','{2}')". \
                 format(label, message['msg_id'], actor)
@@ -27,9 +27,9 @@ class Modifier:
             raise (InternalServerError(description="Error retrieving messages from database"))
 
     @staticmethod
-    def remove_label(label, message, user_urn):
+    def remove_label(label, message, user):
         """delete a label from status table"""
-        actor = user_urn if User(user_urn).is_respondent else message['survey']
+        actor = user.user_uuid if user.is_respondent else message['survey']
         try:
             query = "DELETE FROM status WHERE label = '{0}' and msg_id = '{1}' and actor = '{2}'". \
                 format(label, message['msg_id'], actor)
@@ -40,38 +40,38 @@ class Modifier:
             raise (InternalServerError(description="Error retrieving messages from database"))
 
     @staticmethod
-    def add_archived(message, user_urn):
+    def add_archived(message, user):
         """Add archived label"""
         archive = Labels.ARCHIVE.value
         if archive not in message['labels']:
-            Modifier.add_label(archive, message, user_urn)
+            Modifier.add_label(archive, message, user)
             return True
 
     @staticmethod
-    def del_archived(message, user_urn):
+    def del_archived(message, user):
         """Remove archive label from status"""
         archive = Labels.ARCHIVE.value
         if archive in message['labels']:
-            Modifier.remove_label(archive, message, user_urn)
+            Modifier.remove_label(archive, message, user)
         return True
 
     @staticmethod
-    def add_unread(message, user_urn):
+    def add_unread(message, user):
         """Add unread label to status"""
         unread = Labels.UNREAD.value
         inbox = Labels.INBOX.value
         if inbox in message['labels']:
-            Modifier.add_label(unread, message, user_urn)
+            Modifier.add_label(unread, message, user)
             return True
 
     @staticmethod
-    def del_unread(message, user_urn):
+    def del_unread(message, user):
         """Remove unread label from status"""
         inbox = Labels.INBOX.value
         unread = Labels.UNREAD.value
         if inbox in message['labels'] and unread in message['labels'] and message['read_date'] == None:
             Saver().save_msg_event(message['msg_id'], 'Read')
-        Modifier.remove_label(unread, message, user_urn)
+        Modifier.remove_label(unread, message, user)
         return True
 
     @staticmethod

--- a/app/repository/retriever.py
+++ b/app/repository/retriever.py
@@ -14,17 +14,15 @@ logger = wrap_logger(logging.getLogger(__name__))
 class Retriever:
     """Created when retrieving messages"""
     @staticmethod
-    def retrieve_message_list(page, limit, user_urn, ru=None, survey=None, cc=None, label=None,
+    def retrieve_message_list(page, limit, user, ru=None, survey=None, cc=None, label=None,
                               business=None, descend=True):
         """returns list of messages from db"""
-        user = User(user_urn)
         conditions = []
         status_conditions = []
 
         if user.is_respondent:
-            status_conditions.append(Status.actor == str(user_urn))
+            status_conditions.append(Status.actor == str(user.user_uuid))
         else:
-            #  default survey given this will change once integrated with party service which will provide survey types for internal user
             if survey is not None:
                 status_conditions.append(Status.actor == str(survey))
             else:
@@ -72,14 +70,13 @@ class Retriever:
         return True, result
 
     @staticmethod
-    def retrieve_thread_list(page, limit, user_urn):
+    def retrieve_thread_list(page, limit, user):
         """returns list of threads from db"""
-        user = User(user_urn)
         status_conditions = []
         conditions = []
 
         if user.is_respondent:
-            status_conditions.append(Status.actor == str(user_urn))
+            status_conditions.append(Status.actor == str(user.user_uuid))
         else:
             status_conditions.append(Status.actor == 'BRES')
 
@@ -108,7 +105,7 @@ class Retriever:
         return True, result
 
     @staticmethod
-    def retrieve_message(message_id, user_urn):
+    def retrieve_message(message_id, user):
         """returns single message from db"""
         db_model = SecureMessage()
 
@@ -120,19 +117,18 @@ class Retriever:
             logger.error(e)
             raise(InternalServerError(description="Error retrieving message from database"))
 
-        message = result.serialize(user_urn)
+        message = result.serialize(user)
 
         return message
 
     @staticmethod
-    def retrieve_thread(thread_id, user_urn, _survey='BRES'):
+    def retrieve_thread(thread_id, user, _survey='BRES'):
         """returns list of messages for thread id"""
 
-        user = User(user_urn)
         status_conditions = []
 
         if user.is_respondent:
-            status_conditions.append(Status.actor == str(user_urn))
+            status_conditions.append(Status.actor == str(user.user_uuid))
         else:
             status_conditions.append(Status.actor == str(_survey))
 
@@ -156,12 +152,12 @@ class Retriever:
         conversation = []
 
         for msg in result:
-            conversation.append(msg.serialize(user_urn))
+            conversation.append(msg.serialize(user))
 
         return conversation
 
     @staticmethod
-    def retrieve_draft(message_id, user_urn):
+    def retrieve_draft(message_id, user):
         """returns single draft from db"""
 
         try:
@@ -173,7 +169,7 @@ class Retriever:
             logger.error(e)
             raise (InternalServerError(description="Error retrieving draft from database"))
 
-        message = result.serialize(user_urn)
+        message = result.serialize(user)
 
         return message
 
@@ -195,7 +191,7 @@ class Retriever:
         return resp
 
     @staticmethod
-    def check_msg_id_is_a_draft(draft_id, user_urn):
+    def check_msg_id_is_a_draft(draft_id, user):
         """Check msg_id is that of a valid draft and return true/false if no ID is present"""
         try:
             result = SecureMessage.query.filter(SecureMessage.msg_id == draft_id)\
@@ -207,4 +203,4 @@ class Retriever:
         if result is None:
             return False, result
         else:
-            return True, result.serialize(user_urn)
+            return True, result.serialize(user)

--- a/app/resources/threads.py
+++ b/app/resources/threads.py
@@ -16,10 +16,9 @@ class ThreadById(Resource):
     @staticmethod
     def get(thread_id):
         """Get messages by thread id"""
-        user_urn = g.user_urn
         # check user is authorised to view message
         message_service = Retriever()
-        conversation = message_service.retrieve_thread(thread_id, user_urn)
+        conversation = message_service.retrieve_thread(thread_id, g.user)
         resp = jsonify(conversation)
 
         return resp
@@ -34,10 +33,10 @@ class ThreadList(Resource):
         string_query_args, page, limit, ru, survey, cc, label, business, desc = get_options(request.args)
 
         message_service = Retriever()
-        status, result = message_service.retrieve_thread_list(page, limit, g.user_urn)
+        status, result = message_service.retrieve_thread_list(page, limit, g.user)
 
         if status:
             resp = paginated_list_to_json(result, page, limit, request.host_url,
-                                                       g.user_urn, string_query_args, THREAD_LIST_ENDPOINT)
+                                                       g.user, string_query_args, THREAD_LIST_ENDPOINT)
             resp.status_code = 200
             return resp

--- a/app/validation/user.py
+++ b/app/validation/user.py
@@ -2,15 +2,17 @@
 class User:
     """Determines whether the user is internal or external"""
 
-    user_urn = None
+    user_uuid = None
+    role = None
 
-    def __init__(self, user_urn):
-        self.user_urn = user_urn
+    def __init__(self, user_uuid, role):
+        self.user_uuid = user_uuid
+        self.role = role
 
     @property
     def is_internal(self):
-        return bool('internal' in self.user_urn)
+        return bool(self.role == 'internal')
 
     @property
     def is_respondent(self):
-        return bool('respondent' in self.user_urn)
+        return bool(self.role == 'respondent')

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -25,7 +25,8 @@ class FlaskTestCase(unittest.TestCase):
         AlertUser.alert_method = mock.Mock(AlertViaGovNotify)
 
         token_data = {
-            "user_urn": "respondent.12345678910"
+            "user_uuid": "internal.12345678910",
+            "role": "internal"
         }
         encrypter = Encrypter(_private_key=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY,
                               _private_key_password=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY_PASSWORD,
@@ -296,7 +297,8 @@ class FlaskTestCase(unittest.TestCase):
         msg_id = save_data['msg_id']
 
         token_data = {
-            "user_urn": "internal.12345678910"
+            "user_uuid": "internal.12345678910",
+            "role": "internal"
         }
         encrypter = Encrypter(_private_key=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY,
                               _private_key_password=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY_PASSWORD,

--- a/tests/app/test_authenticator.py
+++ b/tests/app/test_authenticator.py
@@ -14,7 +14,8 @@ class AuthenticationTestCase(unittest.TestCase):
         """Authenticate request using correct JWT"""
         expected_res = {'status': "ok"}
         data = {
-                  "user_urn": "12345678910"
+                  "user_uuid": "12345678910",
+                  "role": "internal"
                 }
         encrypter = Encrypter(_private_key=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY,
                               _private_key_password=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY_PASSWORD,
@@ -42,8 +43,7 @@ class AuthenticationTestCase(unittest.TestCase):
 
     def test_authentication_jwt_user_urn_missing_fail(self):
         """Authenticate request with missing user_urn claim"""
-        expected_res = Response(response="Missing user_urn or invalid user_urn supplied to access this Microservice "
-                                         "Resource", status=400, mimetype="text/html")
+
         data = {
         }
 
@@ -52,8 +52,8 @@ class AuthenticationTestCase(unittest.TestCase):
                               _public_key=settings.SM_USER_AUTHENTICATION_PUBLIC_KEY)
         signed_jwt = encode(data)
         encrypted_jwt = encrypter.encrypt_token(signed_jwt)
-        res = check_jwt(encrypted_jwt)
-        self.assertEqual(res.response, expected_res.response)
+        with self.assertRaises(BadRequest):
+            check_jwt(encrypted_jwt)
 
     def test_authentication_jwt_not_encrypted_fail(self):
         """Authenticate request using JWT without encryption"""
@@ -69,7 +69,8 @@ class AuthenticationTestCase(unittest.TestCase):
         """Authenticate request using authenticate function and with correct header data"""
         expected_res = {'status': "ok"}
         data = {
-                  "user_urn": "12345678910"
+                  "user_uuid": "12345678910",
+                  "role": "internal"
                 }
         encrypter = Encrypter(_private_key=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY,
                               _private_key_password=settings.SM_USER_AUTHENTICATION_PRIVATE_KEY_PASSWORD,

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -12,6 +12,7 @@ from app.repository import database
 from app.repository.modifier import Modifier
 from app.repository.retriever import Retriever
 from app.validation.domain import DraftSchema
+from app.validation.user import User
 
 
 class ModifyTestCaseHelper:
@@ -60,6 +61,9 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             database.db.create_all()
             self.db = database.db
 
+        self.user_internal = User('internal.21345', 'internal')
+        self.user_respondent = User('respondent.21345', 'respondent')
+
     def test_archived_label_is_added_to_message(self):
         """testing message is added to database with archived label attached"""
         self.populate_database(1)
@@ -74,9 +78,9 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
                 msg_id = str(names[0])
                 message_service = Retriever()
                 # pass msg_id and user urn
-                message = message_service.retrieve_message(msg_id, 'respondent.21345')
-                Modifier.add_archived(message, 'respondent.21345', )
-                message = message_service.retrieve_message(msg_id, 'respondent.21345')
+                message = message_service.retrieve_message(msg_id, self.user_respondent)
+                Modifier.add_archived(message, self.user_respondent, )
+                message = message_service.retrieve_message(msg_id, self.user_respondent)
                 self.assertCountEqual(message['labels'], ['SENT', 'ARCHIVE'])
 
     def test_archived_label_is_removed_from_message(self):
@@ -92,12 +96,12 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             with current_app.test_request_context():
                 msg_id = str(names[0])
                 message_service = Retriever()
-                message = message_service.retrieve_message(msg_id, 'respondent.21345')
+                message = message_service.retrieve_message(msg_id, self.user_respondent)
                 modifier = Modifier()
-                modifier.add_archived(message, 'respondent.21345')
-                message = message_service.retrieve_message(msg_id, 'respondent.21345')
-                modifier.del_archived(message, 'respondent.21345', )
-                message = message_service.retrieve_message(msg_id, 'respondent.21345')
+                modifier.add_archived(message, self.user_respondent)
+                message = message_service.retrieve_message(msg_id, self.user_respondent)
+                modifier.del_archived(message, self.user_respondent, )
+                message = message_service.retrieve_message(msg_id, self.user_respondent)
                 self.assertCountEqual(message['labels'], ['SENT'])
 
     def test_unread_label_is_removed_from_message(self):
@@ -113,10 +117,10 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             with current_app.test_request_context():
                 msg_id = str(names[0])
                 message_service = Retriever()
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 modifier = Modifier()
-                modifier.del_unread(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                modifier.del_unread(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 self.assertCountEqual(message['labels'], ['INBOX'])
 
     def test_unread_label_is_added_to_message(self):
@@ -132,11 +136,11 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             with current_app.test_request_context():
                 msg_id = str(names[0])
                 message_service = Retriever()
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 modifier = Modifier()
-                modifier.del_unread(message, 'internal.21345')
-                modifier.add_unread(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                modifier.del_unread(message, self.user_internal)
+                modifier.add_unread(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 self.assertCountEqual(message['labels'], ['UNREAD', 'INBOX'])
 
     def test_add_archive_is_added_to_internal(self):
@@ -152,11 +156,11 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             with current_app.test_request_context():
                 msg_id = str(names[0])
                 message_service = Retriever()
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
-                Modifier.del_archived(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
-                Modifier.add_archived(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                message = message_service.retrieve_message(msg_id, self.user_internal)
+                Modifier.del_archived(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
+                Modifier.add_archived(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 self.assertCountEqual(message['labels'], ['UNREAD', 'INBOX', 'ARCHIVE'])
 
     def test_read_date_is_set(self):
@@ -173,9 +177,9 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
                 msg_id = str(names[0])
                 message_service = Retriever()
                 modifier = Modifier()
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
-                modifier.del_unread(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                message = message_service.retrieve_message(msg_id, self.user_internal)
+                modifier.del_unread(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 self.assertIsNotNone(message['read_date'])
 
     def test_read_date_is_not_reset(self):
@@ -192,13 +196,13 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
                 msg_id = str(names[0])
                 message_service = Retriever()
                 modifier = Modifier()
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
-                modifier.del_unread(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                message = message_service.retrieve_message(msg_id, self.user_internal)
+                modifier.del_unread(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 read_date_set = message['read_date']
-                modifier.add_unread(message, 'internal.21345')
-                modifier.del_unread(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                modifier.add_unread(message, self.user_internal)
+                modifier.del_unread(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 self.assertEqual(message['read_date'], read_date_set)
 
     def test_draft_label_is_deleted(self):
@@ -321,17 +325,17 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
                 msg_id = str(names[0])
                 message_service = Retriever()
                 modifier = Modifier()
-                message = message_service.retrieve_message(msg_id, 'respondent.21345')
-                modifier.add_archived(message, 'respondent.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
-                modifier.add_archived(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'respondent.21345')
-                modifier.del_archived(message, 'respondent.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
-                modifier.del_archived(message, 'internal.21345')
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                message = message_service.retrieve_message(msg_id, self.user_respondent)
+                modifier.add_archived(message, self.user_respondent)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
+                modifier.add_archived(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_respondent)
+                modifier.del_archived(message, self.user_respondent)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
+                modifier.del_archived(message, self.user_internal)
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 self.assertCountEqual(message['labels'], ['UNREAD', 'INBOX'])
-                message = message_service.retrieve_message(msg_id, 'internal.21345')
+                message = message_service.retrieve_message(msg_id, self.user_internal)
                 self.assertCountEqual(message['labels'], ['UNREAD', 'INBOX'])
 
     def test_exception_for_add_label_raises(self):
@@ -341,14 +345,14 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             database.db.drop_all()
             with current_app.test_request_context():
                 with self.assertRaises(InternalServerError):
-                    Modifier.add_label('UNREAD', {'survey': 'survey'}, 'internal.12425')
+                    Modifier.add_label('UNREAD', {'survey': 'survey'}, self.user_internal)
 
     def test_exception_for_remove_label_raises(self):
         with app.app_context():
             database.db.drop_all()
             with current_app.test_request_context():
                 with self.assertRaises(InternalServerError):
-                    Modifier.remove_label('UNREAD', {'survey': 'survey'}, 'internal.12425')
+                    Modifier.remove_label('UNREAD', {'survey': 'survey'}, self.user_internal)
 
     def test_exception_for_del_draft_raises(self):
         with app.app_context():
@@ -362,12 +366,12 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             database.db.drop_all()
             with current_app.test_request_context():
                 with self.assertRaises(InternalServerError):
-                    Modifier.replace_current_draft('internal.1245','Richard')
+                    Modifier.replace_current_draft(self.user_internal,'Richard')
 
     def test_replace_current_recipient_status_raises(self):
         with app.app_context():
             database.db.drop_all()
             with current_app.test_request_context():
                 with self.assertRaises(InternalServerError):
-                    Modifier.replace_current_recipient_status('internal.1245','Torrance')
+                    Modifier.replace_current_recipient_status(self.user_internal, 'Torrance')
 

--- a/tests/app/test_user.py
+++ b/tests/app/test_user.py
@@ -7,19 +7,19 @@ class UserTestCase(unittest.TestCase):
 
     def test_is_respondent_true(self):
         """test uses is_respondent property of User with respondent urn"""
-        self.assertTrue(User('respondent.00000.00000').is_respondent)
+        self.assertTrue(User('respondent.00000.00000', 'respondent').is_respondent)
 
     def test_is_respondent_false(self):
         """test uses is_respondent property of User with internal urn"""
-        self.assertFalse(User('internal.00000.00000').is_respondent)
+        self.assertFalse(User('internal.00000.00000', 'internal').is_respondent)
 
     def test_is_internal_true(self):
         """test uses is_internal property of User with internal urn"""
-        self.assertTrue(User('internal.00000.00000').is_internal)
+        self.assertTrue(User('internal.00000.00000', 'internal').is_internal)
 
     def test_is_internal_false(self):
         """test uses is_internal property of User with respondent urn"""
-        self.assertFalse(User('respondent.00000.00000').is_internal)
+        self.assertFalse(User('respondent.00000.00000', 'respondent').is_internal)
 
 
 if __name__ == '__main__':

--- a/tests/app/test_utilities.py
+++ b/tests/app/test_utilities.py
@@ -8,6 +8,7 @@ from app.repository.retriever import Retriever
 from tests.app.test_retriever import RetrieverTestCaseHelper
 from app.common import utilities
 from app.constants import MESSAGE_QUERY_LIMIT
+from app.validation.user import User
 
 
 class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
@@ -25,14 +26,16 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
             database.db.create_all()
             self.db = database.db
 
+        self.user = User('respondent.21345', 'respondent')
+
     def test_paginated_to_json_returns_correct_messages_len(self):
         """turns paginated result list to json checking correct amount of messages are given"""
         self.populate_database(MESSAGE_QUERY_LIMIT - 1)
         with app.app_context():
             with current_app.test_request_context():
-                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, 'respondent.21345')[1]
+                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, self.user)[1]
                 json_data = utilities.paginated_list_to_json(resp, 1, MESSAGE_QUERY_LIMIT,
-                                                                  "http://localhost:5050/", 'respondent.21345',
+                                                                  "http://localhost:5050/", self.user,
                                                                   string_query_args='?')
                 data = json.loads(json_data.get_data())
                 self.assertEqual(len(data['messages']), (MESSAGE_QUERY_LIMIT - 1))
@@ -42,9 +45,9 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         self.populate_database(MESSAGE_QUERY_LIMIT - 1)
         with app.app_context():
             with current_app.test_request_context():
-                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, 'respondent.21345')[1]
+                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, self.user)[1]
                 json_data = utilities.paginated_list_to_json(resp, 1, MESSAGE_QUERY_LIMIT,
-                                                                  "http://localhost:5050/", 'respondent.21345',
+                                                                  "http://localhost:5050/", self.user,
                                                                   string_query_args='?')
                 data = json.loads(json_data.get_data())
                 self.assertEqual(data['messages'][4]['_links']['self']['href'],
@@ -55,9 +58,9 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         self.populate_database(MESSAGE_QUERY_LIMIT * 2)
         with app.app_context():
             with current_app.test_request_context():
-                resp = Retriever().retrieve_message_list(2, MESSAGE_QUERY_LIMIT, 'respondent.21345')[1]
+                resp = Retriever().retrieve_message_list(2, MESSAGE_QUERY_LIMIT, self.user)[1]
                 json_data = utilities.paginated_list_to_json(resp, 2, MESSAGE_QUERY_LIMIT,
-                                                                  "http://localhost:5050/", 'respondent.21345',
+                                                                  "http://localhost:5050/", self.user,
                                                                   string_query_args='?')
                 data = json.loads(json_data.get_data())
                 self.assertTrue('prev' in data['_links'])
@@ -67,9 +70,9 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         self.populate_database(MESSAGE_QUERY_LIMIT - 1)
         with app.app_context():
             with current_app.test_request_context():
-                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, 'respondent.21345')[1]
+                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, self.user)[1]
                 json_data = utilities.paginated_list_to_json(resp, 1, MESSAGE_QUERY_LIMIT,
-                                                                  "http://localhost:5050/", 'respondent.21345',
+                                                                  "http://localhost:5050/", self.user,
                                                                   string_query_args='?')
                 data = json.loads(json_data.get_data())
                 self.assertFalse('prev' in data['_links'])
@@ -79,9 +82,9 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         self.populate_database(MESSAGE_QUERY_LIMIT * 2)
         with app.app_context():
             with current_app.test_request_context():
-                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, 'respondent.21345')[1]
+                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, self.user)[1]
                 json_data = utilities.paginated_list_to_json(resp, 1, MESSAGE_QUERY_LIMIT,
-                                                                  "http://localhost:5050/", 'respondent.21345',
+                                                                  "http://localhost:5050/", self.user,
                                                                   string_query_args='?')
                 data = json.loads(json_data.get_data())
                 self.assertTrue('next' in data['_links'])
@@ -91,9 +94,9 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         self.populate_database(MESSAGE_QUERY_LIMIT - 1)
         with app.app_context():
             with current_app.test_request_context():
-                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, 'respondent.21345')[1]
+                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, self.user)[1]
                 json_data = utilities.paginated_list_to_json(resp, 1, MESSAGE_QUERY_LIMIT,
-                                                                  "http://localhost:5050/", 'respondent.21345',
+                                                                  "http://localhost:5050/", self.user,
                                                                   string_query_args='?')
                 data = json.loads(json_data.get_data())
                 self.assertFalse('next' in data['_links'])
@@ -103,9 +106,9 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         self.populate_database(MESSAGE_QUERY_LIMIT - 1)
         with app.app_context():
             with current_app.test_request_context():
-                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, 'respondent.21345')[1]
+                resp = Retriever().retrieve_message_list(1, MESSAGE_QUERY_LIMIT, self.user)[1]
                 json_data = utilities.paginated_list_to_json(resp, 1, MESSAGE_QUERY_LIMIT,
-                                                                  "http://localhost:5050/", 'respondent.21345',
+                                                                  "http://localhost:5050/", self.user,
                                                                   string_query_args='?')
                 data = json.loads(json_data.get_data())
                 self.assertEqual(data['_links']['self']['href'],

--- a/tests/behavioural/features/messages_get.feature
+++ b/tests/behavioural/features/messages_get.feature
@@ -22,12 +22,12 @@ Feature: Get Messages list Endpoint
 
  Scenario: As an external user I would like to be able to view a list of messages
     Given an external user has multiple messages
-    When the user requests all messages
+    When the external user requests all messages
     Then all of that users messages are returned
 
  Scenario: As an internal user I would like to be able to view a list of messages
     Given an internal user has multiple messages
-    When the user requests all messages
+    When the internal user requests all messages
     Then all of that users messages are returned
 
   Scenario: Respondent and internal user sends multiple messages and Respondent retrieves the list of sent messages 

--- a/tests/behavioural/features/request_check.feature
+++ b/tests/behavioural/features/request_check.feature
@@ -2,17 +2,32 @@ Feature: Checking all request pass authorisation
    """ requests to any endpoint all hit the same authorisation point before being passed to the specific endpoint """
 
   Scenario: GET request without a user urn in header
-    Given no user urn is in the header
+    Given no user uuid is in the header
     When a GET request is made
     Then a 400 error status is returned
 
   Scenario: POST request without a user urn in header
-    Given no user urn is in the header
+    Given no user uuid is in the header
     When a POST request is made
     Then a 400 error status is returned
 
   Scenario: PUT request without a user urn in header
-    Given no user urn is in the header
+    Given no user uuid is in the header
+    When a PUT request is made
+    Then a 400 error status is returned
+
+  Scenario: GET request without a user urn in header
+    Given no role is in the header
+    When a GET request is made
+    Then a 400 error status is returned
+
+  Scenario: POST request without a user urn in header
+    Given no role is in the header
+    When a POST request is made
+    Then a 400 error status is returned
+
+  Scenario: PUT request without a user urn in header
+    Given no role is in the header
     When a PUT request is made
     Then a 400 error status is returned
 

--- a/tests/behavioural/features/steps/draft_get.py
+++ b/tests/behavioural/features/steps/draft_get.py
@@ -13,7 +13,8 @@ import uuid
 
 url = "http://localhost:5050/draft/{0}"
 token_data = {
-            "user_urn": "respondent.2134"
+            "user_uuid": "respondent.2134",
+            "role": "respondent"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}

--- a/tests/behavioural/features/steps/draft_post.py
+++ b/tests/behavioural/features/steps/draft_post.py
@@ -13,7 +13,8 @@ import nose
 
 url = "http://localhost:5050/draft/save"
 token_data = {
-            "user_urn": "000000000"
+            "user_uuid": "000000000",
+            "role": "internal"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}

--- a/tests/behavioural/features/steps/draft_put.py
+++ b/tests/behavioural/features/steps/draft_put.py
@@ -8,7 +8,10 @@ from app.authentication.jwe import Encrypter
 from app import settings, constants
 
 url = "http://localhost:5050/draft/{0}/modify"
-token_data = {'user_urn': '00000000000'}
+token_data = {
+            "user_uuid": "000000000",
+            "role": "internal"
+        }
 headers = {'Content-Type': 'application/json', 'Authorization': ''}
 
 

--- a/tests/behavioural/features/steps/drafts_get.py
+++ b/tests/behavioural/features/steps/drafts_get.py
@@ -11,7 +11,8 @@ from app import settings
 
 url = "http://localhost:5050/drafts"
 token_data = {
-            "user_urn": "respondent.2134"
+            "user_uuid": "respondent.2134",
+            "role": "respondent"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}

--- a/tests/behavioural/features/steps/message_get.py
+++ b/tests/behavioural/features/steps/message_get.py
@@ -10,7 +10,8 @@ from app import settings
 
 url = "http://localhost:5050/message/{0}"
 token_data = {
-            "user_urn": "000000000"
+            "user_uuid": "000000000",
+            "role": "internal"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}
@@ -41,6 +42,8 @@ headers['Authorization'] = update_encrypted_jwt()
 def step_impl_there_is_a_message_to_be_retrieved(context):
     data['urn_to'] = 'BRES'
     data['urn_from'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
                                               headers=headers)
     msg_resp = json.loads(context.response.data)
@@ -49,7 +52,8 @@ def step_impl_there_is_a_message_to_be_retrieved(context):
 
 @when("the get request is made with a correct message id")
 def step_impl_the_get_request_is_made_with_a_correct_message_id(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url.format(context.msg_id), headers=headers)
 
@@ -125,7 +129,8 @@ def step_impl_a_respondent_sends_a_message(context):
 
 @when("the respondent wants to see the message")
 def step_impl_the_respondent_wants_to_see_the_message(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url.format(context.msg_id), headers=headers)
 
@@ -141,6 +146,9 @@ def step_impl_the_retrieved_message_should_have_label_sent(context):
 def step_impl_an_internal_user_sends_a_message(context):
     data['urn_to'] = 'respondent.122342'
     data['urn_from'] = 'internal.12344'
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().post("http://localhost:5050/message/send",
                                                           data=flask.json.dumps(data), headers=headers)
     msg_resp = json.loads(context.response.data)
@@ -149,7 +157,8 @@ def step_impl_an_internal_user_sends_a_message(context):
 
 @when("the internal user wants to see the message")
 def step_impl_the_internal_user_wants_to_see_the_message(context):
-    token_data['user_urn'] = 'internal.12344'
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url.format(context.msg_id), headers=headers)
 
@@ -167,6 +176,9 @@ def step_impl_the_retrieved_message_should_havethe_labels_inbox_and_unread(conte
 
 @given('there is a draft message to be retrieved')
 def step_impl_draft_message_can_be_retrieved(context):
+    token_data['user_uuid'] = '9976a558-c529-4652-806e-fac1b8d4fdcb'
+    token_data['role'] = 'respondent'
+    headers['Authorization'] = update_encrypted_jwt()
     data.update({'urn_from': '9976a558-c529-4652-806e-fac1b8d4fdcb',
                  'subject': 'test',
                  'body': 'Test',
@@ -174,7 +186,7 @@ def step_impl_draft_message_can_be_retrieved(context):
                  'collection_case': 'collection case1',
                  'reporting_unit': 'reporting case1',
                  'business_name': 'ABusiness',
-                 'survey': 'survey'})
+                 'survey': 'BRES'})
     response = app.test_client().post("http://localhost:5050/draft/save", data=json.dumps(data),
                                       headers=headers)
     context.resp_data = json.loads(response.data)
@@ -182,7 +194,8 @@ def step_impl_draft_message_can_be_retrieved(context):
 
 @when('the get request is made with a draft message id')
 def step_impl_the_draft_is_requested(context):
-    token_data['user_urn'] = '9976a558-c529-4652-806e-fac1b8d4fdcb'
+    token_data['user_uuid'] = '9976a558-c529-4652-806e-fac1b8d4fdcb'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url.format(context.resp_data['msg_id']), headers=headers)
 

--- a/tests/behavioural/features/steps/message_post.py
+++ b/tests/behavioural/features/steps/message_post.py
@@ -14,7 +14,8 @@ from app import settings
 
 url = "http://localhost:5050/message/send"
 token_data = {
-            "user_urn": "000000000"
+            "user_uuid": "000000000",
+            "role": "internal"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}

--- a/tests/behavioural/features/steps/message_put.py
+++ b/tests/behavioural/features/steps/message_put.py
@@ -11,7 +11,8 @@ from app import settings
 
 url = "http://localhost:5050/message/{}/modify"
 token_data = {
-            "user_urn": "000000000"
+            "user_uuid": "000000000",
+            "role": "internal"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}
@@ -115,6 +116,9 @@ def step_impl_message_has_been_read(context):
     reset_db()
     data['urn_to'] = 'internal.12344'
     data['urn_from'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
+    headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().post("http://localhost:5050/message/send",
                                               data=flask.json.dumps(data), headers=headers)
     msg_resp = json.loads(context.response.data)
@@ -122,7 +126,8 @@ def step_impl_message_has_been_read(context):
 
     modify_data['action'] = 'remove'
     modify_data['label'] = 'UNREAD'
-    token_data['user_urn'] = data['urn_to']
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().put(url.format(context.msg_id),
                                              data=flask.json.dumps(modify_data), headers=headers)

--- a/tests/behavioural/features/steps/messages_get.py
+++ b/tests/behavioural/features/steps/messages_get.py
@@ -10,7 +10,8 @@ from app import settings
 
 url = "http://localhost:5050/messages"
 token_data = {
-            "user_urn": "000000000"
+            "user_uuid": "000000000",
+            "role": "internal"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}
@@ -48,6 +49,10 @@ def reset_db():
 @given("a respondent sends multiple messages")
 def step_impl_respondent_sends_multiple_messages(context):
     reset_db()
+
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
+    headers['Authorization'] = update_encrypted_jwt()
     for x in range(0, 2):
         data['urn_to'] = 'internal.12344'
         data['urn_from'] = 'respondent.122342'
@@ -57,7 +62,8 @@ def step_impl_respondent_sends_multiple_messages(context):
 
 @when("the respondent gets their messages")
 def step_impl_respondent_gets_their_messages(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url, headers=headers)
 
@@ -74,6 +80,11 @@ def step_impl_retrieved_messages_should_have_sent_labels(context):
 @given("a Internal user sends multiple messages")
 def step_impl_internal_user_sends_multiple_messages(context):
     reset_db()
+
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
         data['urn_from'] = 'internal.12344'
@@ -83,7 +94,8 @@ def step_impl_internal_user_sends_multiple_messages(context):
 
 @when("the Internal user gets their messages")
 def step_impl_internal_user_gets_their_messages(context):
-    token_data['user_urn'] = 'internal.122342'
+    token_data['user_uuid'] = 'internal.122342'
+    token_data['role'] = 'internal'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url, headers=headers)
 
@@ -114,7 +126,8 @@ def step_implmultiple_messages_sent_to_external_user(context):
 
 @when("the external user navigates to their messages")
 def step_impl_external_user_navigates_to_their_messages(context):
-    token_data['user_urn'] = 'respondent.123'
+    token_data['user_uuid'] = 'respondent.123'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url, headers=headers)
 
@@ -130,11 +143,21 @@ def step_impl_messages_are_displayed(context):
 @given('a respondent and an Internal user sends multiple messages')
 def step_impl_respondant_and_internal_user_send_multiple_messages(context):
     reset_db()
+
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
         data['urn_from'] = 'internal.12344'
         context.response = app.test_client().post("http://localhost:5050/message/send",
                                                   data=flask.json.dumps(data), headers=headers)
+
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
+    headers['Authorization'] = update_encrypted_jwt()
+
     for x in range(0, 2):
         data['urn_to'] = 'internal.12344'
         data['urn_from'] = 'respondent.122342'
@@ -144,7 +167,8 @@ def step_impl_respondant_and_internal_user_send_multiple_messages(context):
 
 @when('the Respondent gets their sent messages')
 def step_impl_respondent_gets_their_sent_messages(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?label=SENT'), headers=headers)
 
@@ -164,11 +188,16 @@ def step_impl_the_retrieved_messaages_all_have_sent_labels(context):
 def step_impl_internal_user_sends_multiple_messages_with_different_ru(context):
     reset_db()
 
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
         data['urn_from'] = 'internal.12344'
         context.response = app.test_client().post("http://localhost:5050/message/send",
                                                   data=flask.json.dumps(data), headers=headers)
+
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
         data['urn_from'] = 'internal.12344'
@@ -179,7 +208,8 @@ def step_impl_internal_user_sends_multiple_messages_with_different_ru(context):
 
 @when('the Respondent gets their messages with particular reporting unit')
 def step_impl_respondent_gets_their_messages_with_particular_ru(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?ru=AnotherReportingUnit'), headers=headers)
 
@@ -197,6 +227,10 @@ def step_impl_assert_correct_ru(context):
 def step_impl_respondent_retrieves_list_of_messages_with_busines_name(context):
     reset_db()
 
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
         data['urn_from'] = 'internal.12344'
@@ -212,7 +246,8 @@ def step_impl_respondent_retrieves_list_of_messages_with_busines_name(context):
 
 @when('the Respondent gets their messages with particular business name')
 def step_impl_respondent_retrieves_messages_with_particular_business_name(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?business=AnotherBusiness'), headers=headers)
 
@@ -231,6 +266,10 @@ def step_impl_assert_messages_have_correct_business_name(context):
 @given('a Internal user sends multiple messages with different survey')
 def step_impl_internal_user_sends_multiple_messages_with_different_survey(context):
     reset_db()
+
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
 
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
@@ -267,6 +306,10 @@ def step_impl_retrieved_messages_shoud_have_correct_survey(context):
 def step_impl_internal_user_sends_multiple_messages_with_different_collection_case(context):
     reset_db()
 
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+
     for x in range(0, 2):
         data['urn_to'] = 'respondent.122342'
         data['urn_from'] = 'internal.12344'
@@ -282,7 +325,8 @@ def step_impl_internal_user_sends_multiple_messages_with_different_collection_ca
 
 @when('the Respondent gets their messages with particular collection case')
 def step_impl_respondent_retrieves_messaegs_with_particular_collection_case(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?cc=AnotherCollectionCase'), headers=headers)
 
@@ -344,16 +388,20 @@ def step_impl_assert_no_message_has_draft_inbox_label(context):
 @given("an external user has multiple messages")
 def step_impl_external_user_has_multiple_messages(context):
     reset_db()
-    token_data['user_urn'] = 'respondent.123'
+    token_data['user_uuid'] = 'internal.123'
+    token_data['role'] = 'internal'
     headers['Authorization'] = update_encrypted_jwt()
-    data['urn_from'] = 'respondent.123'
+    data['urn_from'] = 'internal.123'
     for x in range(0, 2):
         app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data), headers=headers)
         app.test_client().post("http://localhost:5050/draft/save", data=flask.json.dumps(data), headers=headers)
 
 
-@when("the user requests all messages")
+@when("the external user requests all messages")
 def step_impl_external_user_requests_all_messages(context):
+    token_data['user_uuid'] = 'internal.123'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
     request = app.test_client().get(url, headers=headers)
     context.response = flask.json.loads(request.data)
 
@@ -363,7 +411,7 @@ def step_impl_assert_correct_number_of_messages_returned(context):
     nose.tools.assert_equal(len(context.response['messages']), 4)
 
 
-# Scenario: As an external user I would like to be able to view a list of messages
+# Scenario: As an internal user I would like to be able to view a list of messages
 @given("an internal user has multiple messages")
 def step_impl_internal_user_has_multiple_messages(context):
     reset_db()
@@ -375,20 +423,35 @@ def step_impl_internal_user_has_multiple_messages(context):
         app.test_client().post("http://localhost:5050/draft/save", data=flask.json.dumps(data), headers=headers)
 
 
+@when("the internal user requests all messages")
+def step_impl_internal_user_requests_all_messages(context):
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+    request = app.test_client().get(url, headers=headers)
+    context.response = flask.json.loads(request.data)
+
+
 # Scenario: As a user I would like to be able to view a list of inbox messages
 @given("a internal user receives multiple messages")
 def step_impl_internal_user_receives_multiple_messages(context):
     reset_db()
+
+    token_data['user_uuid'] = 'respondent.123'
+    token_data['role'] = 'respondent'
+    headers['Authorization'] = update_encrypted_jwt()
+
     for x in range(0, 2):
-        data['urn_to'] = 'respondent.123'
-        data['urn_from'] = 'internal.123'
+        data['urn_to'] = 'internal.123'
+        data['urn_from'] = 'respondent.123'
         context.response = app.test_client().post("http://localhost:5050/message/send",
                                                   data=flask.json.dumps(data), headers=headers)
 
 
 @when("the internal user gets their inbox messages")
 def step_impl_internal_user_gets_their_inbox_messages(context):
-    token_data['user_urn'] = 'respondent.123'
+    token_data['user_uuid'] = 'internal.123'
+    token_data['role'] = 'internal'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?label=INBOX'), headers=headers)
 
@@ -610,6 +673,10 @@ def step_impl_assert_all_messages_returned(context):
 @given("a respondent user receives multiple messages")
 def step_impl_respondent_recieves_multiple_messages(context):
     reset_db()
+    token_data['user_uuid'] = 'internal.123'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+
     for x in range(0, 2):
         data['urn_to'] = 'respondent.123'
         data['urn_from'] = 'internal.123'
@@ -619,6 +686,7 @@ def step_impl_respondent_recieves_multiple_messages(context):
 
 @when("the respondent user gets their inbox messages")
 def step_impl_assert_respondent_gets_their_inbox_messages(context):
-    token_data['user_urn'] = 'respondent.123'
+    token_data['user_uuid'] = 'respondent.123'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get('{0}{1}'.format(url, '?label=INBOX'), headers=headers)

--- a/tests/behavioural/features/steps/request_check.py
+++ b/tests/behavioural/features/steps/request_check.py
@@ -34,7 +34,7 @@ def step_impl_no_user_urn_in_the_header(context):
 
 
 @given("no role is in the header")
-def step_impl_no_user_urn_in_the_header(context):
+def step_impl_no_role_in_the_header(context):
     if 'user_uuid' not in token_data:
         token_data['user_uuid'] = "000000000"
 

--- a/tests/behavioural/features/steps/request_check.py
+++ b/tests/behavioural/features/steps/request_check.py
@@ -6,7 +6,8 @@ from app import settings
 import nose.tools
 
 token_data = {
-            "user_urn": "000000000"
+            "user_uuid": "000000000",
+            "role": "internal"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}
@@ -25,10 +26,20 @@ headers['Authorization'] = update_encrypted_jwt()
 # Scenario: GET request without a user urn in header
 
 
-@given("no user urn is in the header")
+@given("no user uuid is in the header")
 def step_impl_no_user_urn_in_the_header(context):
-    if 'user_urn' in token_data:
-        del token_data['user_urn']
+    if 'user_uuid' in token_data:
+        del token_data['user_uuid']
+        headers['Authorization'] = update_encrypted_jwt()
+
+
+@given("no role is in the header")
+def step_impl_no_user_urn_in_the_header(context):
+    if 'user_uuid' not in token_data:
+        token_data['user_uuid'] = "000000000"
+
+    if 'role' in token_data:
+        del token_data['role']
         headers['Authorization'] = update_encrypted_jwt()
 
 

--- a/tests/behavioural/features/steps/thread_get.py
+++ b/tests/behavioural/features/steps/thread_get.py
@@ -11,7 +11,8 @@ import uuid
 
 url = "http://localhost:5050/thread/{0}"
 token_data = {
-            "user_urn": "000000000"
+            "user_uuid": "000000000",
+            "role": "internal"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}
@@ -52,10 +53,18 @@ def step_impl_respondent_and_internal_user_hav_a_conversation(context):
 
     data['thread_id'] = 'AConversation'
     for _ in range(0, 2):
+        token_data['user_uuid'] = 'respondent.122342'
+        token_data['role'] = 'respondent'
+        headers['Authorization'] = update_encrypted_jwt()
+
         data['urn_to'] = 'internal.12344'
         data['urn_from'] = 'respondent.122342'
         context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
                                                   headers=headers)
+        token_data['user_uuid'] = 'internal.12344'
+        token_data['role'] = 'internal'
+        headers['Authorization'] = update_encrypted_jwt()
+
         data['urn_to'] = 'respondent.122342'
         data['urn_from'] = 'internal.12344'
         context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
@@ -64,7 +73,8 @@ def step_impl_respondent_and_internal_user_hav_a_conversation(context):
 
 @when("the respondent gets this conversation")
 def step_impl_respondent_gets_conversation(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url.format(data['thread_id']), headers=headers)
 
@@ -79,7 +89,8 @@ def step_impl_assert_all_messages_in_conversation_are_received(context):
 
 @when("the internal user gets this conversation")
 def step_impl_internal_user_gets_conversation(context):
-    token_data['user_urn'] = 'internal.12344'
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url.format(data['thread_id']), headers=headers)
 
@@ -88,11 +99,15 @@ def step_impl_internal_user_gets_conversation(context):
 
 @given("internal user creates a draft")
 def step_impl_internal_user_creates_a_draft(context):
-        data['urn_to'] = 'respondent.122342'
-        data['urn_from'] = 'internal.12344'
-        data['thread_id'] = 'AConversation'
-        context.response = app.test_client().post("http://localhost:5050/draft/save", data=flask.json.dumps(data),
-                                                  headers=headers)
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+
+    data['urn_to'] = 'respondent.122342'
+    data['urn_from'] = 'internal.12344'
+    data['thread_id'] = 'AConversation'
+    context.response = app.test_client().post("http://localhost:5050/draft/save", data=flask.json.dumps(data),
+                                              headers=headers)
 
 #   Scenario: Respondent and internal user have a conversation, including a draft, and internal user retrieves the conversation
 

--- a/tests/behavioural/features/steps/threads_get.py
+++ b/tests/behavioural/features/steps/threads_get.py
@@ -10,7 +10,8 @@ from app import settings
 
 url = "http://localhost:5050/threads"
 token_data = {
-            "user_urn": "000000000"
+            "user_uuid": "000000000",
+            "role": "internal"
         }
 
 headers = {'Content-Type': 'application/json', 'Authorization': ''}
@@ -53,10 +54,19 @@ def step_impl_respondent_and_internal_user_hav_multiple_conversations(context):
     for x in range(0,3):
         data['thread_id'] = 'AConversation{0}'.format(x)
         for _ in range(0, 2):
+            token_data['user_uuid'] = 'respondent.122342'
+            token_data['role'] = 'respondent'
+            headers['Authorization'] = update_encrypted_jwt()
+
             data['urn_to'] = 'internal.12344'
             data['urn_from'] = 'respondent.122342'
             context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
                                                       headers=headers)
+
+            token_data['user_uuid'] = 'internal.12344'
+            token_data['role'] = 'internal'
+            headers['Authorization'] = update_encrypted_jwt()
+
             data['urn_to'] = 'respondent.122342'
             data['urn_from'] = 'internal.12344'
             context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
@@ -67,7 +77,8 @@ def step_impl_respondent_and_internal_user_hav_multiple_conversations(context):
 
 @when("the respondent gets all conversations")
 def step_impl_respondent_gets_all_conversations(context):
-    token_data['user_urn'] = 'respondent.122342'
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url, headers=headers)
 
@@ -92,7 +103,8 @@ def step_impl_most_recent_message_from_each_conversation_returned(context):
 
 @when("the internal user gets all conversations")
 def step_impl_internal_user_gets_all_conversations(context):
-    token_data['user_urn'] = 'internal.12344'
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
     headers['Authorization'] = update_encrypted_jwt()
     context.response = app.test_client().get(url, headers=headers)
 
@@ -105,10 +117,19 @@ def step_impl_internal_user_has_conversation_with_draft(context):
 
     data['thread_id'] = 'AnotherConversation'
 
+    token_data['user_uuid'] = 'respondent.122342'
+    token_data['role'] = 'respondent'
+    headers['Authorization'] = update_encrypted_jwt()
+
     data['urn_to'] = 'internal.12344'
     data['urn_from'] = 'respondent.122342'
     context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),
                                               headers=headers)
+
+    token_data['user_uuid'] = 'internal.12344'
+    token_data['role'] = 'internal'
+    headers['Authorization'] = update_encrypted_jwt()
+
     data['urn_to'] = 'respondent.122342'
     data['urn_from'] = 'internal.12344'
     context.response = app.test_client().post("http://localhost:5050/message/send", data=flask.json.dumps(data),


### PR DESCRIPTION
**What is the context of this PR?**
- Added user uuid and role claims into JWT 
- Changes made to "User" class to work with the user_uuid and role
- When authorising the request a global user object is created, which is then passed into various functions instead of passing the global user_urn.
- Unit tests and BDD tests modified to work with UUIDs instead of user_urns

Link to Trello card
https://trello.com/c/EW2mmOJ5/312-ts-188-every-sm-api-call-to-require-a-jwt-which-will-include-a-user-uuid-and-a-claim-as-to-if-the-current-user-is-an-internal-us
Describe what you have changed and why, link to other PRs or Issues as appropriate.

**How to review**

Any notes for the reviewer  (include screenshots if appropriate).
