### PR TITLE
Bug fixed and bdd tests added

### DIFF
--- a/app/resources/drafts.py
+++ b/app/resources/drafts.py
@@ -43,26 +43,18 @@ class DraftSave(Resource):
             res.status_code = 400
             return res
 
-    def _save_draft(self, draft, saver=Saver()):
+    @staticmethod
+    def _save_draft(draft, saver=Saver()):
         saver.save_message(draft.data)
 
         if draft.data.urn_to is not None and len(draft.data.urn_to) != 0:
             uuid_to = draft.data.urn_to if g.user.is_internal else draft.data.survey
-            self._save_draft_status(saver, draft.data.msg_id, uuid_to, draft.data.survey,
-                                      Labels.DRAFT_INBOX.value)
+            saver.save_msg_status(uuid_to, draft.data.msg_id, Labels.DRAFT_INBOX.value)
 
         uuid_from = draft.data.urn_from if g.user.is_respondent else draft.data.survey
-
-        self._save_draft_status(saver, draft.data.msg_id, uuid_from, draft.data.survey, Labels.DRAFT.value)
+        saver.save_msg_status(uuid_from, draft.data.msg_id, Labels.DRAFT.value)
 
         saver.save_msg_event(draft.data.msg_id, 'Draft_Saved')
-
-    @staticmethod
-    def _save_draft_status(saver, msg_id, person, survey, label):
-        """Save labels with correct actor for internal and respondent"""
-
-        if person is not None and len(person) != 0:
-            saver.save_msg_status(person, msg_id, label)
 
 
 class DraftById(Resource):

--- a/app/resources/messages.py
+++ b/app/resources/messages.py
@@ -56,6 +56,10 @@ class MessageSend(Resource):
             if is_draft is True:
                 draft_id = post_data['msg_id']
                 post_data['msg_id'] = ''
+
+                if post_data['thread_id'] == draft_id:
+                    post_data['thread_id'] = ''
+
             else:
                 raise (BadRequest(description="Message can not include msg_id"))
 

--- a/tests/behavioural/features/message_post.feature
+++ b/tests/behavioural/features/message_post.feature
@@ -15,10 +15,26 @@ Feature: Message Send Endpoint
     When the draft is sent
     Then a msg_id in the response
 
+  Scenario: Send a draft and receive a msg_id
+    Given a message is identified as a draft
+    When the draft is sent
+    Then a msg_id in the response
+
   Scenario: Send a draft and receive a thread_id
     Given a message is identified as a draft
     When the draft is sent
     Then a thread_id in the response
+    And thread_id is the same as msg_id
+
+  Scenario: Send a draft and receive a msg_id
+    Given a message is identified as a draft
+    When the draft is sent
+    Then a msg_id in the response
+
+  Scenario: Send a draft which is a reply to another message
+      Given a message is identified as a draft which is a reply to another message
+      When the draft is sent
+      Then thread_id is not the same as msg_id
 
   Scenario: Submit a message with a missing "To" field and receive a 400 error
     Given  the 'To' field is empty

--- a/tests/behavioural/features/steps/message_post.py
+++ b/tests/behavioural/features/steps/message_post.py
@@ -114,7 +114,7 @@ def step_impl_a_message_is_a_draft_reply(context):
 
 
 @then('thread_id is not the same as msg_id')
-def step_impl_thread_id_and_msg_id_are_equal(context):
+def step_impl_thread_id_and_msg_id_are_not_equal(context):
     resp = json.loads(context.response.data)
     nose.tools.assert_not_equals(resp['thread_id'], resp['msg_id'])
     nose.tools.assert_equal(resp['thread_id'], '25e9172c-62d9-4ff7-98ac-661300ae9446')

--- a/tests/behavioural/features/steps/message_post.py
+++ b/tests/behavioural/features/steps/message_post.py
@@ -71,7 +71,7 @@ def step_impl_a_message_is_a_draft(context):
                        'urn_from': 'respondent.test',
                        'subject': 'Hello World',
                        'body': 'Test',
-                       'thread_id': '',
+                       'thread_id': context.msg_id,
                        'collection_case': 'collection case1',
                        'reporting_unit': 'reporting case1',
                        'business_name': 'ABusiness',
@@ -81,6 +81,43 @@ def step_impl_a_message_is_a_draft(context):
 @when('the draft is sent')
 def step_impl_draft_is_sent(context):
     context.response = app.test_client().post(url, data=json.dumps(context.message), headers=headers)
+
+
+#  Scenario: Send a draft which is a reply to another message
+
+@given('a message is identified as a draft which is a reply to another message')
+def step_impl_a_message_is_a_draft_reply(context):
+    data.update({'urn_to': 'test',
+                 'urn_from': 'respondent.test',
+                 'subject': 'Hello World',
+                 'body': 'Test',
+                 'thread_id': '25e9172c-62d9-4ff7-98ac-661300ae9446',
+                 'collection_case': 'collection case1',
+                 'reporting_unit': 'reporting case1',
+                 'business_name': 'ABusiness',
+                 'survey': 'survey'})
+
+    context.post_draft = app.test_client().post("http://localhost:5050/draft/save", data=json.dumps(data),
+                                                headers=headers)
+    msg_resp = json.loads(context.post_draft.data)
+    context.msg_id = msg_resp['msg_id']
+    context.message = {'msg_id': context.msg_id,
+                       'urn_to': 'test',
+                       'urn_from': 'respondent.test',
+                       'subject': 'Hello World',
+                       'body': 'Test',
+                       'thread_id': '25e9172c-62d9-4ff7-98ac-661300ae9446',
+                       'collection_case': 'collection case1',
+                       'reporting_unit': 'reporting case1',
+                       'business_name': 'ABusiness',
+                       'survey': 'survey'}
+
+
+@then('thread_id is not the same as msg_id')
+def step_impl_thread_id_and_msg_id_are_equal(context):
+    resp = json.loads(context.response.data)
+    nose.tools.assert_not_equals(resp['thread_id'], resp['msg_id'])
+    nose.tools.assert_equal(resp['thread_id'], '25e9172c-62d9-4ff7-98ac-661300ae9446')
 
 
 # Scenario 3: Submit a message with a missing "To" field and receive a 400 error
@@ -238,6 +275,12 @@ def step_impl_msg_id_in_response(context):
 def step_impl_thread_id_in_response(context):
     resp = json.loads(context.response.data)
     nose.tools.assert_true(resp['thread_id'] is not None)
+
+
+@then('thread_id is the same as msg_id')
+def step_impl_thread_id_and_msg_id_are_equal(context):
+    resp = json.loads(context.response.data)
+    nose.tools.assert_equal(resp['thread_id'], resp['msg_id'])
 
 
 @then("a 400 error status is returned")


### PR DESCRIPTION
**What is the context of this PR?**

Link to Trello card
https://trello.com/c/GsjsyZgy/338-d-136-message-post-of-draft-issue-with-threads

Describe what you have changed and why, link to other PRs or Issues as appropriate.
- In the message send endpoint there is now a check for if the thread id is the same as the msg id when posting a draft if it is then this thread id is not persisted.
- BDD tests added to cover this bug 
- Refactored draft save endpoint as there was a function which added no value

**How to review**

Any notes for the reviewer  (include screenshots if appropriate).
