### PR TITLE
Log if business details or user details not found in party service.

### DIFF
--- a/app/common/utilities.py
+++ b/app/common/utilities.py
@@ -114,14 +114,14 @@ def get_business_details_by_ru(rus):
 
     details = []
 
-    for x in rus:
+    for ru in rus:
 
-        detail = party.get_business_details(x)
+        detail = party.get_business_details(ru)
 
         if detail.status_code == 200:
             details.append(json.loads(detail.data))
         else:
-            raise ExpectationFailed(description="Received an unexpected response from Party service")
+            logger.info("No details found for RU ID {}".format(ru))
 
     return details
 
@@ -137,7 +137,7 @@ def get_details_by_uuids(uuids):
         if detail.status_code == 200:
             respondent_details.append(json.loads(detail.data))
         else:
-            raise ExpectationFailed(description="Received an unexpected response from Party service")
+            logger.info("No details found for user {}".format(uuid))
 
     return respondent_details
 

--- a/tests/app/test_mock_party.py
+++ b/tests/app/test_mock_party.py
@@ -116,21 +116,21 @@ class PartyTestCase(unittest.TestCase):
         self.assertEqual(user_details[4], expected)
 
 
-    def test_get_user_details_by_invalid_uuid(self):
-        """Test that function returns error when invalid uuid present"""
-
-        list_uuids = ['f62dfda8-73b0-4e0e-97cf-1b06327a6778']
-
-        with self.assertRaises(ExpectationFailed):
-            get_details_by_uuids(list_uuids)
-
-    def test_get_business_details_by_invalid_ru(self):
-        """Test that function returns error when invalid ru present"""
-
-        list_ru = ['f62dfda8-73b0-4e0e-97cf-1b06327a6778']
-
-        with self.assertRaises(ExpectationFailed):
-            get_business_details_by_ru(list_ru)
+    # def test_get_user_details_by_invalid_uuid(self):
+    #     """Test that function returns error when invalid uuid present"""
+    #
+    #     list_uuids = ['f62dfda8-73b0-4e0e-97cf-1b06327a6778']
+    #
+    #     with self.assertRaises(ExpectationFailed):
+    #         get_details_by_uuids(list_uuids)
+    #
+    # def test_get_business_details_by_invalid_ru(self):
+    #     """Test that function returns error when invalid ru present"""
+    #
+    #     list_ru = ['f62dfda8-73b0-4e0e-97cf-1b06327a6778']
+    #
+    #     with self.assertRaises(ExpectationFailed):
+    #         get_business_details_by_ru(list_ru)
 
     def test_message_by_id_replaces_uuids(self):
         """Test get message by id endpoint replaces to and from with user details"""


### PR DESCRIPTION
API was returning 417 if it could not populate business details or user details for messages found in the database.

This change allows the API to return the messages even if no matching data in party service.
