### PR TITLE
upadting returned error messages for saved message

### DIFF
--- a/app/validation/domain.py
+++ b/app/validation/domain.py
@@ -123,19 +123,21 @@ class MessageSchema(Schema):
     def validate_not_present(data, field_name):
         if field_name in data.keys():
             logger.error('Field cannot be set', field_name=field_name)
-            raise ValidationError("{0} can not be set.".format(field_name))
+            raise ValidationError("{0} can not be set".format(field_name))
 
     def validate_non_zero_field_length(self, field_name, length, max_field_len):
         if length <= 0:
             logger.error('Field not populated', field_name=field_name)
-            raise ValidationError('{0} field not populated.'.format(field_name))
+            if field_name == "Body":
+                field_name = "message"
+            raise ValidationError('Please enter a {0}'.format(field_name.lower()))
         self.validate_field_length(field_name, length, max_field_len)
 
     @staticmethod
     def validate_field_length(field_name, length, max_field_len, data=None):
         if length > max_field_len:
             logger.error('Field is too large', field_name=field_name, length=length, max_field_len=max_field_len)
-            raise ValidationError('{0} field length must not be greater than {1}.'.format(field_name, max_field_len), field_name, [], data)
+            raise ValidationError('{0} field length must not be greater than {1}'.format(field_name, max_field_len), field_name, [], data)
 
 
 class DraftSchema(Schema):

--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -102,7 +102,7 @@ class MessageSchemaTestCase(unittest.TestCase):
     def test_body_too_big_fails_validation(self):
         """marshalling message with body field too long """
         self.json_message['body'] = "x" * (MAX_BODY_LEN + 1)
-        expected_error = 'Body field length must not be greater than {0}.'.format(MAX_BODY_LEN)
+        expected_error = 'Body field length must not be greater than {0}'.format(MAX_BODY_LEN)
 
         with app.app_context():
             g.user = User(self.json_message['msg_from'], 'respondent')
@@ -120,7 +120,7 @@ class MessageSchemaTestCase(unittest.TestCase):
             g.user = User(message['msg_from'], 'respondent')
             schema = MessageSchema()
             errors = schema.load(message)[1]
-        self.assertTrue(errors == {'body': ['Body field not populated.']})
+        self.assertTrue(errors == {'body': ['Please enter a message']})
 
     def test_missing_subject_fails_validation(self):
         """marshalling message with no subject field """
@@ -135,7 +135,7 @@ class MessageSchemaTestCase(unittest.TestCase):
     def test_subject_field_too_long_causes_error(self):
         """marshalling message with subject field too long"""
         self.json_message['subject'] = "x" * (MAX_SUBJECT_LEN + 1)
-        expected_error = 'Subject field length must not be greater than {0}.'.format(MAX_SUBJECT_LEN)
+        expected_error = 'Subject field length must not be greater than {0}'.format(MAX_SUBJECT_LEN)
         with app.app_context():
             g.user = User(self.json_message['msg_from'], 'respondent')
             schema = MessageSchema()
@@ -155,7 +155,7 @@ class MessageSchemaTestCase(unittest.TestCase):
     def test_thread_field_too_long_causes_error(self):
         """marshalling message with thread_id field too long"""
         self.json_message['thread_id'] = "x" * (MAX_THREAD_LEN + 1)
-        expected_error = 'Thread field length must not be greater than {0}.'.format(MAX_THREAD_LEN)
+        expected_error = 'Thread field length must not be greater than {0}'.format(MAX_THREAD_LEN)
         with app.app_context():
             g.user = User(self.json_message['msg_from'], 'respondent')
             schema = MessageSchema()
@@ -182,7 +182,7 @@ class MessageSchemaTestCase(unittest.TestCase):
             schema = MessageSchema()
             errors = schema.load(message)[1]
 
-        self.assertTrue(errors == {'_schema': ['read_date can not be set.']})
+        self.assertTrue(errors == {'_schema': ['read_date can not be set']})
 
     def test_missing_survey_causes_error(self):
         """marshalling message with no survey field"""
@@ -192,7 +192,7 @@ class MessageSchemaTestCase(unittest.TestCase):
             g.user = User(self.json_message['msg_from'], 'respondent')
             schema = MessageSchema()
             errors = schema.load(self.json_message)[1]
-        self.assertTrue(errors == {'survey': ['Survey field not populated.']})
+        self.assertTrue(errors == {'survey': ['Please enter a survey']})
 
     def test_same_to_from_causes_error(self):
         """marshalling message with same to and from field"""


### PR DESCRIPTION
**What is the context of this PR?**

https://trello.com/c/OCyBb8FX/527-sm070-external-validate-secure-message-before-sending-m-5

Changed returned error messages for secure messaging validation

**How to review**

Use with associated frontstage PR 
https://github.com/ONSdigital/ras-frontstage/pull/159