### PR TITLE
Pass basic auth parameters to downstream services

### DIFF
--- a/app/services/case_service.py
+++ b/app/services/case_service.py
@@ -1,14 +1,13 @@
 import logging
 from flask import json
 import requests
-import app.settings
+from app import settings
 from structlog import wrap_logger
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
 class CaseService:
-
     @staticmethod
     def store_case_event(case_id, user_name):
         """posts the data to the case service"""
@@ -18,8 +17,8 @@ class CaseService:
                      "createdBy": user_name
                      }
 
-        url = app.settings.RM_CASE_POST.format(app.settings.RM_CASE_SERVICE, case_id)
-        case_service_data = requests.post(url, json=json_data, verify=False)
+        url = settings.RM_CASE_POST.format(settings.RM_CASE_SERVICE, case_id)
+        case_service_data = requests.post(url, auth=settings.BASIC_AUTH, json=json_data, verify=False)
         logger.debug('case service post result', status_code=case_service_data.status_code,
                      reason=case_service_data.reason, text=case_service_data.text)
         case_service_dict = json.loads(case_service_data.text)

--- a/app/services/party_service.py
+++ b/app/services/party_service.py
@@ -2,24 +2,28 @@ import logging
 from flask import json
 import requests
 import app.settings
-from app import constants
+from app import constants, settings
 from structlog import wrap_logger
 
 logger = wrap_logger(logging.getLogger(__name__))
 
 
 class PartyService:
-
     @staticmethod
     def get_business_details(ru):
         """Retrieves the business details from the party service"""
 
         url = app.settings.RAS_PARTY_GET_BY_BUSINESS.format(app.settings.RAS_PARTY_SERVICE, ru)
-        party_data = requests.get(url, verify=False)
-        logger.debug('Party service get business details result', status_code=party_data.status_code, reason=party_data.reason, text=party_data.text,
+        party_data = requests.get(url, auth=settings.BASIC_AUTH, verify=False)
+
+        logger.debug('Party service get business details result',
+                     status_code=party_data.status_code,
+                     reason=party_data.reason,
+                     text=party_data.text,
                      url=url)
+
         party_dict = json.loads(party_data.text)
-        if type(party_dict) is list:                    # if id is not a uuid returns a list not a dict
+        if type(party_dict) is list:  # if id is not a uuid returns a list not a dict
             party_dict = {'errors': party_dict[0]}
 
         return party_dict, party_data.status_code
@@ -38,8 +42,15 @@ class PartyService:
             return party_dict, 200
         else:
             url = app.settings.RAS_PARTY_GET_BY_RESPONDENT.format(app.settings.RAS_PARTY_SERVICE, uuid)
-            party_data = requests.get(url, verify=False)
-            logger.debug('Party get user details result', status_code=party_data.status_code, reason=party_data.reason, text=party_data.text,
+            party_data = requests.get(url,
+                                      auth=settings.BASIC_AUTH,
+                                      verify=False)
+
+            logger.debug('Party get user details result',
+                         status_code=party_data.status_code,
+                         reason=party_data.reason,
+                         text=party_data.text,
                          url=url)
+
             party_dict = json.loads(party_data.text)
             return party_dict, party_data.status_code

--- a/app/settings.py
+++ b/app/settings.py
@@ -35,9 +35,15 @@ NOTIFY_VIA_LOGGING = os.getenv('NOTIFY_VIA_LOGGING', '0')
 
 SQLALCHEMY_POOL_SIZE = os.getenv('SQLALCHEMY_POOL_SIZE', None)
 
+# JWT authentication config
 SM_JWT_ALGORITHM = os.getenv('JWT_ALGORITHM', 'HS256')
 SM_JWT_SECRET = os.getenv('JWT_SECRET', 'vrwgLNWEffe45thh545yuby')
 SM_JWT_ENCRYPT = os.getenv('SM_JWT_ENCRYPT', '1')
+
+# Basic auth parameters
+SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME', 'dummy_user')
+SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD', 'dummy_password')
+BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
 
 #  Keys
 SM_USER_AUTHENTICATION_PRIVATE_KEY = open("{0}/jwt-test-keys/sm-user-authentication-encryption-private-key.pem".format(os.getenv('RAS_SM_PATH')))\


### PR DESCRIPTION
**What is the context of this PR?**

https://trello.com/c/ZAvBcNgf/562-defect-23-production-pre-prod-services-communicating-with-eachother

Describe what you have changed and why, link to other PRs or Issues as appropriate.

**How to review**

Basic auth settings have been added for SECURITY_USER_NAME and SECURITY_USER_PASSWORD. Note that these match the names of the environment variables across RAS and RM, as the username/password is to be shared across services (while being distinct per environment). These parameters are passed into downstream calls to party service and case service.


