### PR TITLE
role is no longer required

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -42,8 +42,8 @@ def check_jwt(token):
         if not decoded_jwt_token.get(constants.USER_IDENTIFIER):
             raise BadRequest(description="Missing user_uuid claim,"
                                          "user_uuid is required to access this Microservice Resource")
-        if not decoded_jwt_token.get('role'):
-            raise BadRequest(description="Missing role claim, role is required to access this Microservice Resource")
+        # if not decoded_jwt_token.get('role'):
+        #     raise BadRequest(description="Missing role claim, role is required to access this Microservice Resource")
 
         g.user = User(decoded_jwt_token.get(constants.USER_IDENTIFIER), decoded_jwt_token.get('role'))
 

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -42,8 +42,9 @@ def check_jwt(token):
         if not decoded_jwt_token.get(constants.USER_IDENTIFIER):
             raise BadRequest(description="Missing user_uuid claim,"
                                          "user_uuid is required to access this Microservice Resource")
-        # if not decoded_jwt_token.get('role'):
-        #     raise BadRequest(description="Missing role claim, role is required to access this Microservice Resource")
+        if not decoded_jwt_token.get('role'):
+            # raise BadRequest(description="Missing role claim, role is required to access this Microservice Resource")
+            decoded_jwt_token['role'] = 'respondent'
 
         g.user = User(decoded_jwt_token.get(constants.USER_IDENTIFIER), decoded_jwt_token.get('role'))
 

--- a/tests/behavioural/features/request_check.feature
+++ b/tests/behavioural/features/request_check.feature
@@ -16,20 +16,20 @@ Feature: Checking all request pass authorisation
     When a PUT request is made
     Then a bad request status code (400) is returned
 
-  Scenario: GET request without a role in header
-    Given no role is in the header
-    When a GET request is made
-    Then a bad request status code (400) is returned
-
-  Scenario: POST request without a role in header
-    Given no role is in the header
-    When a POST request is made
-    Then a bad request status code (400) is returned
-
-  Scenario: PUT request without a role in header
-    Given no role is in the header
-    When a PUT request is made
-    Then a bad request status code (400) is returned
+#  Scenario: GET request without a role in header
+#    Given no role is in the header
+#    When a GET request is made
+#    Then a bad request status code (400) is returned
+#
+#  Scenario: POST request without a role in header
+#    Given no role is in the header
+#    When a POST request is made
+#    Then a bad request status code (400) is returned
+#
+#  Scenario: PUT request without a role in header
+#    Given no role is in the header
+#    When a PUT request is made
+#    Then a bad request status code (400) is returned
 
   Scenario Outline: User tries to use endpoint with the wrong method
     Given user wants to use <endpoint> endpoint


### PR DESCRIPTION
**What is the context of this PR?**

https://trello.com/c/caqTLg2d/566-bug-if-a-bres-user-token-is-encypted-with-an-empty-role-then-the-user-can-still-get-messages

Commented out the authentication around role so it is not a required field in the JWT anymore

**How to review**

To test this I've been removing the role in frontstage in `frontstage/jwt.py line 22`
