### PR TITLE
user can no longer view messages from DRAFT_INBOX

### DIFF
--- a/app/authorization/authorizer.py
+++ b/app/authorization/authorizer.py
@@ -24,7 +24,7 @@ class Authorizer:
         if user.user_uuid == message['msg_from']:
             return True
 
-        if user.user_uuid in message['msg_to']:
+        if user.user_uuid in message['msg_to'] and 'DRAFT_INBOX' not in message['labels']:
             return True
 
         logger.info('User was refused viewing of message', user_uuid=user.user_uuid, role=user.role, message_id=message['msg_id'])

--- a/tests/app/test_authorizer.py
+++ b/tests/app/test_authorizer.py
@@ -32,9 +32,21 @@ class AuthorizerTestCase(unittest.TestCase):
     def test_external_user_is_authorised_to_view_msg_if_they_received_message(self):
         """A respondent is authorised to view a message sent to them """
         user = User('1234', 'external')
-        message = {'msg_from': constants.BRES_USER, 'msg_to': ['1111', '1234']}
+        message = {'msg_from': constants.BRES_USER, 'msg_to': ['1111', '1234'], 'labels': ['DRAFT']}
         sut = Authorizer()
         expected = True
+
+        result = sut.can_user_view_message(user, message)
+
+        self.assertTrue(expected == result)
+
+    def test_external_user_is_not_authorised_to_view_msg_if_message_in_DRAFT_INBOX(self):
+        """A respondent is authorised to view a message sent to them """
+        user = User('1234', 'external')
+        message = {'msg_id': '1234567890', 'msg_from': constants.BRES_USER,
+                   'msg_to': ['1111', '1234'], 'labels': ['DRAFT_INBOX']}
+        sut = Authorizer()
+        expected = False
 
         result = sut.can_user_view_message(user, message)
 

--- a/tests/behavioural/features/draft_get.feature
+++ b/tests/behavioural/features/draft_get.feature
@@ -57,3 +57,11 @@ Feature: Get draft by id
     Then a success status code (200) is returned
       And the response should include a valid etag
 
+  Scenario: An internal user saves a draft and the respondent is not authorized to read it
+    Given sending from internal to respondent
+      And  the message is saved as draft
+      And  the user is set as respondent
+      And  the draft is read
+    Then  a forbidden status code (403) is returned
+
+

--- a/tests/behavioural/features/draft_post.feature
+++ b/tests/behavioural/features/draft_post.feature
@@ -299,9 +299,9 @@ Feature: Draft Save Endpoint
 
   Scenario: An Internal user saves a message and a respondent replies , the thread id should not equal the message id
     Given sending from internal to respondent
-      And  the message is saved as draft
+      And  the message is sent
       And  the user is set as respondent
-      And  the draft is read
+      And  the message is read
       And  the from is set to respondent
       And  the to is set to internal
       And  the body is set to '--New body--'

--- a/tests/behavioural/features/draft_post.feature
+++ b/tests/behavioural/features/draft_post.feature
@@ -71,7 +71,6 @@ Feature: Draft Save Endpoint
     When the message is saved as draft
     Then a created status code (201) is returned
 
-
   Scenario: Respondent saves a draft from too long should receive a 400
     Given sending from respondent to internal
       And  the from is too long
@@ -325,7 +324,6 @@ Feature: Draft Save Endpoint
     Then  a created status code (201) is returned
       And  retrieved message thread id is not equal to message id
       And  the thread id is equal in all responses
-
 
     Scenario: An internal user sends a message and a respondent saves draft then sends as reply validate thread id is correct
     Given sending from internal to respondent


### PR DESCRIPTION
**What is the context of this PR?**

https://trello.com/c/nvudG3Bb/567-bug-if-a-user-saves-a-draft-the-intended-recipient-can-read-it-if-they-request-drafts-with-a-draftinbox-label

Added check to make sure the user cannot view message if he is the `msg_to` and the message is labelled `DRAFT_INBOX`

**How to review**

Try to view a message with the `DRAFT_INBOX` label where the user is the `msg_to`
