### PR TITLE
Limit body size for list of messages

### DIFF
--- a/app/common/utilities.py
+++ b/app/common/utilities.py
@@ -69,7 +69,7 @@ def paginated_list_to_json(paginated_list, page, limit, host_url, user, string_q
 
     for message in paginated_list.items:
         msg_count += 1
-        msg = message.serialize(user)
+        msg = message.serialize(user, body_summary=True)
         msg['_links'] = {"self": {"href": "{0}{1}/{2}".format(host_url, MESSAGE_BY_ID_ENDPOINT, msg['msg_id'])}}
         messages.append(msg)
 

--- a/app/repository/database.py
+++ b/app/repository/database.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from structlog import wrap_logger
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import Column, String, Integer, DateTime, ForeignKey, Index
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy.orm import relationship
 from app import constants
 from app.common.labels import Labels
 


### PR DESCRIPTION
Limited the body size on messages returned in a list to 100 chars.
Also changed data loading in sqlalchemy from the default 'select' to 'dynamic'. 
