### PR TITLE
Subject with only spaces can not be sent

### DIFF
--- a/app/validation/domain.py
+++ b/app/validation/domain.py
@@ -89,7 +89,7 @@ class MessageSchema(Schema):
 
     @validates("subject")
     def validate_subject(self, subject):
-        self.validate_non_zero_field_length("Subject", len(subject), constants.MAX_SUBJECT_LEN)
+        self.validate_non_zero_field_length("Subject", len(subject.strip()), constants.MAX_SUBJECT_LEN)
 
     @validates("thread_id")
     def validate_thread(self, thread_id):

--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -132,6 +132,26 @@ class MessageSchemaTestCase(unittest.TestCase):
             errors = schema.load(self.json_message)[1]
         self.assertTrue(errors == {'subject': ['Missing data for required field.']})
 
+    def test_empty_subject_fails_validation(self):
+        """marshalling message with no subject field """
+        self.json_message['subject'] = ''
+        self.json_message['msg_to'] = ["01b51fcc-ed43-4cdb-ad1c-450f9986859b"]
+        with app.app_context():
+            g.user = User(self.json_message['msg_from'], 'respondent')
+            schema = MessageSchema()
+            errors = schema.load(self.json_message)[1]
+        self.assertTrue(errors == {'subject': ['Please enter a subject']})
+
+    def test_subject_with_only_spaces_fails_validation(self):
+        """marshalling message with no subject field """
+        self.json_message['subject'] = '  '
+        self.json_message['msg_to'] = ["01b51fcc-ed43-4cdb-ad1c-450f9986859b"]
+        with app.app_context():
+            g.user = User(self.json_message['msg_from'], 'respondent')
+            schema = MessageSchema()
+            errors = schema.load(self.json_message)[1]
+        self.assertTrue(errors == {'subject': ['Please enter a subject']})
+
     def test_subject_field_too_long_causes_error(self):
         """marshalling message with subject field too long"""
         self.json_message['subject'] = "x" * (MAX_SUBJECT_LEN + 1)


### PR DESCRIPTION
Subject was passing validation if it only contained spaces. Now it will raise a validation error if the message being sent has a subject just filled with spaces.


Trello: https://trello.com/c/ICXHAdV6/676-secure-messages-sent-with-only-spaces-in-subject-cannot-be-viewed-in-rops