### PR TITLE
Remove db url from healthcheck

### DIFF
--- a/secure_message/resources/health.py
+++ b/secure_message/resources/health.py
@@ -44,7 +44,6 @@ class HealthDetails(Resource):
                    'Version': current_app.config['VERSION'],
                    'SMS Log level': current_app.config['SMS_LOG_LEVEL'],
                    'APP Log Level': current_app.config['APP_LOG_LEVEL'],
-                   'Database URL': current_app.config['SQLALCHEMY_DATABASE_URI'],
                    'API Functionality': func_list,
                    'Using party service mock': party._use_mock,
                    'SM JWT ENCRYPT': current_app.config['SM_JWT_ENCRYPT'],

--- a/tests/app/test_health_monitor.py
+++ b/tests/app/test_health_monitor.py
@@ -46,7 +46,6 @@ class HealthTestCase(unittest.TestCase):
                    'Version': '',
                    'SMS Log level': '',
                    'APP Log Level': '',
-                   'Database URL': '',
                    'API Functionality': '',
                    'Using party service mock': '',
                    'SM JWT ENCRYPT': '',


### PR DESCRIPTION
The healthcheck endpoint was exposing the db url, this has now been removed.