### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,8 @@ ENV BUILD_PACKAGES="build-essential python3-dev python3-pip libpq-dev"
 WORKDIR /app
 COPY . /app
 EXPOSE 5050
+
 RUN apt-get update && apt-get install -y $RUNTIME_PACKAGES $BUILD_PACKAGES
 RUN pip3 install pipenv==8.3.1 && pipenv install --system --deploy
-
-ENV JWT_SECRET testsecret
-ENV SECURITY_USER_NAME admin
-ENV SECURITY_USER_PASSWORD secret
-ENV NOTIFICATION_API_KEY test_notification_api_key
-ENV NOTIFICATION_TEMPLATE_ID test_notification_template_id
-ENV SERVICE_ID test_service_id
-
 ENTRYPOINT ["python3"]
 CMD ["run.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.6
 ENV RUNTIME_PACKAGES="python3"
 ENV BUILD_PACKAGES="build-essential python3-dev python3-pip libpq-dev"
 WORKDIR /app
@@ -6,5 +6,13 @@ COPY . /app
 EXPOSE 5050
 RUN apt-get update && apt-get install -y $RUNTIME_PACKAGES $BUILD_PACKAGES
 RUN pip3 install pipenv==8.3.1 && pipenv install --system --deploy
+
+ENV JWT_SECRET testsecret
+ENV SECURITY_USER_NAME admin
+ENV SECURITY_USER_PASSWORD secret
+ENV NOTIFICATION_API_KEY test_notification_api_key
+ENV NOTIFICATION_TEMPLATE_ID test_notification_template_id
+ENV SERVICE_ID test_service_id
+
 ENTRYPOINT ["python3"]
 CMD ["run.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
     environment:
       SECURE_MESSAGING_DATABASE_URL: postgres://rasmessage:rasmessage@db:5432/messages
       RAS_SM_PATH: ./
+      JWT_SECRET: testsecret
+      SECURITY_USER_NAME: admin
+      SECURITY_USER_PASSWORD: secret
+      NOTIFICATION_API_KEY: test_notification_api_key
+      NOTIFICATION_TEMPLATE_ID: test_notification_template_id
+      SERVICE_ID: test_service_id
     restart: always
     depends_on:
       - db


### PR DESCRIPTION
The f-string notation didn't come until python 3.6 which is why the image was updated.
The dockerfile didn't have any environment variables set so now it'll work out of the
box in accordance with the readme.