### PR TITLE
Fix startup config errors

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,11 +81,10 @@ class Config:
 
     NOTIFY_CASE_SERVICE = os.getenv('NOTIFY_CASE_SERVICE', '1')
 
-    NON_DEFAULT_VARIABLES = ['JWT_SECRET', 'SECURITY_USER_NAME', 'SECURITY_USER_PASSWORD',
+    NON_DEFAULT_VARIABLES = ['SM_JWT_SECRET', 'SECURITY_USER_NAME', 'SECURITY_USER_PASSWORD',
                              'NOTIFICATION_API_KEY', 'SERVICE_ID', 'NOTIFICATION_TEMPLATE_ID']
 
     # These should always be set in the environment on prod
-    JWT_SECRET = os.getenv('JWT_SECRET')
     JWT_ALGORITHM = os.getenv('JWT_ALGORITHM')
     NOTIFY_VIA_GOV_NOTIFY = os.getenv('NOTIFY_VIA_GOV_NOTIFY')
     NOTIFICATION_API_KEY = os.getenv('NOTIFICATION_API_KEY')
@@ -100,7 +99,7 @@ class Config:
 
 class DevConfig(Config):
 
-    JWT_SECRET = os.getenv('JWT_SECRET', 'vrwgLNWEffe45thh545yuby')
+    SM_JWT_SECRET = os.getenv('JWT_SECRET', 'vrwgLNWEffe45thh545yuby')
     JWT_ALGORITHM = os.getenv('JWT_ALGORITHM', 'HS256')
     NOTIFY_VIA_GOV_NOTIFY = os.getenv('NOTIFY_VIA_GOV_NOTIFY', '0')
     NOTIFICATION_API_KEY = os.getenv('NOTIFICATION_API_KEY', 'test_notification_api_key')
@@ -114,16 +113,14 @@ class DevConfig(Config):
 
 class TestConfig(Config):
 
-    JWT_SECRET = 'testsecret'
+    SM_JWT_SECRET = 'testsecret'
     JWT_ALGORITHM = 'HS256'
     NOTIFY_VIA_GOV_NOTIFY = '0'
     NOTIFICATION_API_KEY = 'test_notification_api_key'
     NOTIFICATION_TEMPLATE_ID = 'test_notification_template_id'
     RAS_SM_PATH = './'
-    SM_USER_AUTHENTICATION_PRIVATE_KEY = open(
-        "./jwt-test-keys/sm-user-authentication-encryption-private-key.pem").read()
-    SM_USER_AUTHENTICATION_PUBLIC_KEY = open(
-        "./jwt-test-keys/sm-user-authentication-encryption-public-key.pem").read()
+    SM_USER_AUTHENTICATION_PRIVATE_KEY = open("./jwt-test-keys/sm-user-authentication-encryption-private-key.pem").read()
+    SM_USER_AUTHENTICATION_PUBLIC_KEY = open("./jwt-test-keys/sm-user-authentication-encryption-public-key.pem").read()
     SECURITY_USER_NAME = 'admin'
     SECURITY_USER_PASSWORD = 'secret'
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)

--- a/config.py
+++ b/config.py
@@ -52,7 +52,7 @@ class Config:
 
     # JWT authentication config
     SM_JWT_ALGORITHM = os.getenv('JWT_ALGORITHM', 'HS256')
-    SM_JWT_SECRET = os.getenv('JWT_SECRET')
+    JWT_SECRET = os.getenv('JWT_SECRET')
     SM_JWT_ENCRYPT = os.getenv('SM_JWT_ENCRYPT', '1')
 
     # Keys
@@ -81,7 +81,7 @@ class Config:
 
     NOTIFY_CASE_SERVICE = os.getenv('NOTIFY_CASE_SERVICE', '1')
 
-    NON_DEFAULT_VARIABLES = ['SM_JWT_SECRET', 'SECURITY_USER_NAME', 'SECURITY_USER_PASSWORD',
+    NON_DEFAULT_VARIABLES = ['JWT_SECRET', 'SECURITY_USER_NAME', 'SECURITY_USER_PASSWORD',
                              'NOTIFICATION_API_KEY', 'SERVICE_ID', 'NOTIFICATION_TEMPLATE_ID']
 
     # These should always be set in the environment on prod
@@ -99,7 +99,7 @@ class Config:
 
 class DevConfig(Config):
 
-    SM_JWT_SECRET = os.getenv('JWT_SECRET', 'vrwgLNWEffe45thh545yuby')
+    JWT_SECRET = os.getenv('JWT_SECRET', 'vrwgLNWEffe45thh545yuby')
     JWT_ALGORITHM = os.getenv('JWT_ALGORITHM', 'HS256')
     NOTIFY_VIA_GOV_NOTIFY = os.getenv('NOTIFY_VIA_GOV_NOTIFY', '0')
     NOTIFICATION_API_KEY = os.getenv('NOTIFICATION_API_KEY', 'test_notification_api_key')
@@ -113,7 +113,7 @@ class DevConfig(Config):
 
 class TestConfig(Config):
 
-    SM_JWT_SECRET = 'testsecret'
+    JWT_SECRET = 'testsecret'
     JWT_ALGORITHM = 'HS256'
     NOTIFY_VIA_GOV_NOTIFY = '0'
     NOTIFICATION_API_KEY = 'test_notification_api_key'

--- a/config.py
+++ b/config.py
@@ -89,6 +89,16 @@ class Config:
     NON_DEFAULT_VARIABLES = ['JWT_SECRET', 'SECURITY_USER_NAME', 'SECURITY_USER_PASSWORD',
                              'NOTIFICATION_API_KEY', 'SERVICE_ID', 'NOTIFICATION_TEMPLATE_ID']
 
+    # These should always be set in the environment on prod
+    JWT_SECRET = os.getenv('JWT_SECRET')
+    JWT_ALGORITHM = os.getenv('JWT_ALGORITHM')
+    NOTIFY_VIA_GOV_NOTIFY = os.getenv('NOTIFY_VIA_GOV_NOTIFY')
+    NOTIFICATION_API_KEY = os.getenv('NOTIFICATION_API_KEY')
+    NOTIFICATION_TEMPLATE_ID = os.getenv('NOTIFICATION_TEMPLATE_ID')
+    SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')
+    SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD')
+    SERVICE_ID = os.getenv('SERVICE_ID')
+
 
 class DevConfig(Config):
 
@@ -118,8 +128,3 @@ class TestConfig(Config):
     SECURITY_USER_NAME = 'admin'
     SECURITY_USER_PASSWORD = 'secret'
     SERVICE_ID = 'test_service_id'
-
-
-for var in Config.NON_DEFAULT_VARIABLES:
-    if not os.getenv(var):
-        raise MissingEnvironmentVariable(Config.NON_DEFAULT_VARIABLES)

--- a/config.py
+++ b/config.py
@@ -62,11 +62,6 @@ class Config:
     SM_USER_AUTHENTICATION_PUBLIC_KEY = open(
         f"{RAS_SM_PATH}/jwt-test-keys/sm-user-authentication-encryption-public-key.pem").read()
 
-    # Basic auth parameters
-    SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')
-    SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD')
-    BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
-
     #  password
     SM_USER_AUTHENTICATION_PRIVATE_KEY_PASSWORD = "digitaleq"
 
@@ -95,9 +90,12 @@ class Config:
     NOTIFY_VIA_GOV_NOTIFY = os.getenv('NOTIFY_VIA_GOV_NOTIFY')
     NOTIFICATION_API_KEY = os.getenv('NOTIFICATION_API_KEY')
     NOTIFICATION_TEMPLATE_ID = os.getenv('NOTIFICATION_TEMPLATE_ID')
+    SERVICE_ID = os.getenv('SERVICE_ID')
+
+    # Basic auth parameters
     SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')
     SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD')
-    SERVICE_ID = os.getenv('SERVICE_ID')
+    BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
 
 
 class DevConfig(Config):
@@ -110,12 +108,13 @@ class DevConfig(Config):
         'NOTIFICATION_TEMPLATE_ID', 'test_notification_template_id')
     SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME', 'admin')
     SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD', 'secret')
+    BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
     SERVICE_ID = os.getenv('SERVICE_ID', 'test_service_id')
 
 
 class TestConfig(Config):
 
-    JWT_SECRET = 'vrwgLNWEffe45thh545yuby'
+    JWT_SECRET = 'testsecret'
     JWT_ALGORITHM = 'HS256'
     NOTIFY_VIA_GOV_NOTIFY = '0'
     NOTIFICATION_API_KEY = 'test_notification_api_key'
@@ -127,4 +126,5 @@ class TestConfig(Config):
         "./jwt-test-keys/sm-user-authentication-encryption-public-key.pem").read()
     SECURITY_USER_NAME = 'admin'
     SECURITY_USER_PASSWORD = 'secret'
+    BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
     SERVICE_ID = 'test_service_id'

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,12 +7,7 @@ if __name__ == "__main__":
     os.environ['APP_SETTINGS'] = 'TestConfig'
 
     # NB: the following are set to avoid MissingEnvironmentVariable being raised in config.py
-    os.environ['JWT_SECRET'] = 'testsecret'
-    os.environ['SECURITY_USER_NAME'] = 'admin'
     os.environ['SECURITY_USER_PASSWORD'] = 'secret'
-    os.environ['NOTIFICATION_API_KEY'] = 'test_notification_api_key'
-    os.environ['NOTIFICATION_TEMPLATE_ID'] = 'test_notification_template_id'
-    os.environ['SERVICE_ID'] = 'test_service_id'
 
     from behave import __main__ as behave_executable
     behave = behave_executable.main()

--- a/run_tests.py
+++ b/run_tests.py
@@ -6,9 +6,6 @@ import sys
 if __name__ == "__main__":
     os.environ['APP_SETTINGS'] = 'TestConfig'
 
-    # NB: the following are set to avoid MissingEnvironmentVariable being raised in config.py
-    os.environ['SECURITY_USER_PASSWORD'] = 'secret'
-
     from behave import __main__ as behave_executable
     behave = behave_executable.main()
 

--- a/secure_message/authentication/jwt.py
+++ b/secure_message/authentication/jwt.py
@@ -12,7 +12,7 @@ def encode(data):
     """
     jwt_algorithm = current_app.config['SM_JWT_ALGORITHM']
     jwt_secret = current_app.config['SM_JWT_SECRET']
-
+    print(data)
     return jwt.encode(data, jwt_secret, algorithm=jwt_algorithm, headers={"alg": jwt_algorithm, 'typ': 'jwt'})
 
 

--- a/secure_message/authentication/jwt.py
+++ b/secure_message/authentication/jwt.py
@@ -11,8 +11,7 @@ def encode(data):
     Function to encode python dict data
     """
     jwt_algorithm = current_app.config['SM_JWT_ALGORITHM']
-    jwt_secret = current_app.config['SM_JWT_SECRET']
-    print(data)
+    jwt_secret = current_app.config['JWT_SECRET']
     return jwt.encode(data, jwt_secret, algorithm=jwt_algorithm, headers={"alg": jwt_algorithm, 'typ': 'jwt'})
 
 
@@ -21,6 +20,6 @@ def decode(token):
     Function to decode python dict data
     """
     jwt_algorithm = current_app.config['SM_JWT_ALGORITHM']
-    jwt_secret = current_app.config['SM_JWT_SECRET']
+    jwt_secret = current_app.config['JWT_SECRET']
 
     return jwt.decode(token, jwt_secret, algorithms=[jwt_algorithm])

--- a/tests/app/test_authenticator.py
+++ b/tests/app/test_authenticator.py
@@ -28,6 +28,7 @@ def test_authentication_non_encrypted_jwt_pass(self):
 
 class AuthenticationTestCase(unittest.TestCase):
     """Test case for request authentication"""
+
     def setUp(self):
         """setup test environment"""
         self.app = create_app()

--- a/tests/behavioural/features/steps/common.py
+++ b/tests/behavioural/features/steps/common.py
@@ -54,4 +54,5 @@ def step_impl_reuse_the_nth_sent_message(context, message_index):
 @then("'{message_count}' messages are returned")
 def step_impl_n_messages_returned(context, message_count):
     """ validate that the correct number of messages was returned"""
-    nose.tools.assert_equal(int(message_count), len(context.bdd_helper.messages_responses_data[0]['messages']))
+    nose.tools.assert_equal(int(message_count), len(
+        context.bdd_helper.messages_responses_data[0]['messages']))


### PR DESCRIPTION
**What is the context of this PR?**

Fixes #130. Removes a for loop at the bottom of the config file that checked whether non default vars were set. This would always fail when running dev or test, as these environments expect the `TestConfig` and `DevConfig` config classes to be used.

This PR also removes workarounds put in place to mitigate this bug.
