### PR TITLE
implemented caching mechanism for uiid and ru already called for each…

### DIFF
--- a/secure_message/services/party_service.py
+++ b/secure_message/services/party_service.py
@@ -16,11 +16,6 @@ class PartyService:
 
     @staticmethod
     def get_url(api_param, code):
-        """
-        :param api_param: is the key configuration that represents part of the URI.
-        :param code: is the code to use in the url ( uuid or ru )
-        :return: a formatted url
-        """
         try:
             current_app.config[api_param].format(current_app.config['RAS_PARTY_SERVICE'], code)
         except KeyError:
@@ -45,10 +40,6 @@ class PartyService:
         return party_data.text, party_data.status_code
 
     def get_user_details(self, uuid):
-        """
-        :param uuid:
-        :return: Return user details , unless user is Bres in which case return constant data
-        """
         if uuid == constants.BRES_USER:
             party_dict = {"id": constants.BRES_USER,
                           "firstName": "BRES",

--- a/secure_message/services/party_service.py
+++ b/secure_message/services/party_service.py
@@ -17,7 +17,7 @@ class PartyService:
     @staticmethod
     def get_url(api_param, code):
         try:
-            current_app.config[api_param].format(current_app.config['RAS_PARTY_SERVICE'], code)
+            return current_app.config[api_param].format(current_app.config['RAS_PARTY_SERVICE'], code)
         except KeyError:
             raise KeyError(f"{api_param} not present")
 
@@ -28,7 +28,7 @@ class PartyService:
             logger.info("Party Service: retrieve party data using", ru=ru)
             party_data = requests.get(PartyService.get_url('RAS_PARTY_GET_BY_BUSINESS', ru),
                                       auth=current_app.config['BASIC_AUTH'], verify=False)
-            self.__business_details_cache.update(ru, party_data)
+            self.__business_details_cache[ru] = party_data
         else:
             party_data = self.__business_details_cache.get(ru)
 
@@ -54,7 +54,7 @@ class PartyService:
             logger.info("Party Service: retrieve party data using", uuid=uuid)
             party_data = requests.get(PartyService.get_url('RAS_PARTY_GET_BY_RESPONDENT', uuid),
                                       auth=current_app.config['BASIC_AUTH'], verify=False)
-            self.__users_cache.update(uuid, party_data)
+            self.__users_cache[uuid] = party_data
         else:
             party_data = self.__users_cache.get(uuid)
 

--- a/secure_message/services/party_service.py
+++ b/secure_message/services/party_service.py
@@ -10,18 +10,30 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 class PartyService:
+
+    users_cache = dict()
+    business_details_cache = dict()
+
     @staticmethod
-    def get_business_details(ru):
+    def get_url(api_param, code):
+        """
+        :param api_param:  is the key configuration that that represent part or the URI .
+        :param code: is the code to use in the url ( uuid or ru )
+        :return: a formatted url
+        """
+        if current_app.config[api_param] is None or current_app.config['RAS_PARTY_SERVICE'] is None:
+            raise KeyError("%s not present" % api_param)
+        return current_app.config[api_param].format(current_app.config['RAS_PARTY_SERVICE'], code)
+
+    def get_business_details(self, ru):
         """Retrieves the business details from the party service"""
 
-        url = current_app.config['RAS_PARTY_GET_BY_BUSINESS'].format(current_app.config['RAS_PARTY_SERVICE'], ru)
-        party_data = requests.get(url, auth=current_app.config['BASIC_AUTH'], verify=False)
-
-        logger.debug('Party service get business details result',
-                     status_code=party_data.status_code,
-                     reason=party_data.reason,
-                     text=party_data.text,
-                     url=url)
+        if ru not in self.business_details_cache:
+            party_data = requests.get(PartyService.get_url('RAS_PARTY_GET_BY_BUSINESS', ru),
+                                      auth=current_app.config['BASIC_AUTH'], verify=False)
+            self.users_cache.update(ru, party_data)
+        else:
+            party_data = self.users_cache.get(ru)
 
         if party_data.status_code == 200:
             party_dict = json.loads(party_data.text)
@@ -30,9 +42,11 @@ class PartyService:
         logger.error('Party service failed', status_code=party_data.status_code, text=party_data.text, ru=ru)
         return party_data.text, party_data.status_code
 
-    @staticmethod
-    def get_user_details(uuid):
-        """Return user details , unless user is Bres in which case return constant data"""
+    def get_user_details(self, uuid):
+        """
+        :param uuid:
+        :return: Return user details , unless user is Bres in which case return constant data
+        """
         if uuid == constants.BRES_USER:
             party_dict = {"id": constants.BRES_USER,
                           "firstName": "BRES",
@@ -41,18 +55,16 @@ class PartyService:
                           "telephone": "",
                           "status": "",
                           "sampleUnitType": "BI"}
+            logger.info("UUID is BRES")
             return party_dict, 200
 
-        url = current_app.config['RAS_PARTY_GET_BY_RESPONDENT'].format(current_app.config['RAS_PARTY_SERVICE'], uuid)
-        party_data = requests.get(url,
-                                  auth=current_app.config['BASIC_AUTH'],
-                                  verify=False)
-
-        logger.debug('Party get user details result',
-                     status_code=party_data.status_code,
-                     reason=party_data.reason,
-                     text=party_data.text,
-                     url=url)
+        if uuid not in self.users_cache:
+            logger.info("Executing call to the  party service ")
+            party_data = requests.get(PartyService.get_url('RAS_PARTY_GET_BY_RESPONDENT', uuid),
+                                      auth=current_app.config['BASIC_AUTH'], verify=False)
+            self.users_cache.update(uuid, party_data)
+        else:
+            party_data = self.users_cache.get(uuid)
 
         if party_data.status_code == 200:
             party_dict = json.loads(party_data.text)

--- a/secure_message/services/party_service.py
+++ b/secure_message/services/party_service.py
@@ -11,8 +11,8 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 class PartyService:
 
-    users_cache = dict()
-    business_details_cache = dict()
+    __users_cache = dict()
+    __business_details_cache = dict()
 
     @staticmethod
     def get_url(api_param, code):
@@ -29,12 +29,12 @@ class PartyService:
     def get_business_details(self, ru):
         """Retrieves the business details from the party service"""
 
-        if ru not in self.business_details_cache:
+        if ru not in self.__business_details_cache:
             party_data = requests.get(PartyService.get_url('RAS_PARTY_GET_BY_BUSINESS', ru),
                                       auth=current_app.config['BASIC_AUTH'], verify=False)
-            self.users_cache.update(ru, party_data)
+            self.__business_details_cache.update(ru, party_data)
         else:
-            party_data = self.users_cache.get(ru)
+            party_data = self.__business_details_cache.get(ru)
 
         if party_data.status_code == 200:
             party_dict = json.loads(party_data.text)
@@ -58,13 +58,13 @@ class PartyService:
                           "sampleUnitType": "BI"}
             return party_dict, 200
 
-        if uuid not in self.users_cache:
+        if uuid not in self.__users_cache:
             logger.info("Executing call to the  party service ")
             party_data = requests.get(PartyService.get_url('RAS_PARTY_GET_BY_RESPONDENT', uuid),
                                       auth=current_app.config['BASIC_AUTH'], verify=False)
-            self.users_cache.update(uuid, party_data)
+            self.__users_cache.update(uuid, party_data)
         else:
-            party_data = self.users_cache.get(uuid)
+            party_data = self.__users_cache.get(uuid)
 
         if party_data.status_code == 200:
             party_dict = json.loads(party_data.text)

--- a/secure_message/services/party_service.py
+++ b/secure_message/services/party_service.py
@@ -17,13 +17,14 @@ class PartyService:
     @staticmethod
     def get_url(api_param, code):
         """
-        :param api_param:  is the key configuration that that represent part or the URI .
+        :param api_param:  is the key configuration that represent part or the URI .
         :param code: is the code to use in the url ( uuid or ru )
         :return: a formatted url
         """
-        if current_app.config[api_param] is None or current_app.config['RAS_PARTY_SERVICE'] is None:
-            raise KeyError("%s not present" % api_param)
-        return current_app.config[api_param].format(current_app.config['RAS_PARTY_SERVICE'], code)
+        try:
+            current_app.config[api_param].format(current_app.config['RAS_PARTY_SERVICE'], code)
+        except KeyError:
+            raise KeyError(f"{api_param} not present")
 
     def get_business_details(self, ru):
         """Retrieves the business details from the party service"""
@@ -55,7 +56,6 @@ class PartyService:
                           "telephone": "",
                           "status": "",
                           "sampleUnitType": "BI"}
-            logger.info("UUID is BRES")
             return party_dict, 200
 
         if uuid not in self.users_cache:

--- a/secure_message/services/party_service.py
+++ b/secure_message/services/party_service.py
@@ -17,7 +17,7 @@ class PartyService:
     @staticmethod
     def get_url(api_param, code):
         """
-        :param api_param:  is the key configuration that represent part or the URI .
+        :param api_param: is the key configuration that represents part of the URI.
         :param code: is the code to use in the url ( uuid or ru )
         :return: a formatted url
         """
@@ -30,6 +30,7 @@ class PartyService:
         """Retrieves the business details from the party service"""
 
         if ru not in self.__business_details_cache:
+            logger.info("Party Service: retrieve party data using", ru=ru)
             party_data = requests.get(PartyService.get_url('RAS_PARTY_GET_BY_BUSINESS', ru),
                                       auth=current_app.config['BASIC_AUTH'], verify=False)
             self.__business_details_cache.update(ru, party_data)
@@ -59,7 +60,7 @@ class PartyService:
             return party_dict, 200
 
         if uuid not in self.__users_cache:
-            logger.info("Executing call to the  party service ")
+            logger.info("Party Service: retrieve party data using", uuid=uuid)
             party_data = requests.get(PartyService.get_url('RAS_PARTY_GET_BY_RESPONDENT', uuid),
                                       auth=current_app.config['BASIC_AUTH'], verify=False)
             self.__users_cache.update(uuid, party_data)

--- a/tests/app/test_party_service.py
+++ b/tests/app/test_party_service.py
@@ -21,14 +21,6 @@ class PartyTestCase(unittest.TestCase):
         self.app = create_app()
         self.app.testing = True
 
-    def url_exists(url):
-        r = requests_mock.get(url)
-        if r.status_code == 200:
-            return True
-
-        elif r.status_code == 404:
-            return False
-
     @requests_mock.mock()
     def test_results_returned_from_get_business_get_executed_just_once_for_the_same_ru(self, mock_request):
         """Test get business details sends a request and returns data"""
@@ -41,10 +33,8 @@ class PartyTestCase(unittest.TestCase):
         for retries in range(0, 2):
 
             with self.app.app_context():
-                result_data, result_status = sut.get_business_details(ru)
+                sut.get_business_details(ru)
 
-        self.assertEqual(result_data, {"something": "else"})
-        self.assertEqual(result_status, 200)
         self.assertTrue(mock_request.call_count == 1)
 
     @requests_mock.mock()
@@ -62,18 +52,15 @@ class PartyTestCase(unittest.TestCase):
             mock_request.get(business_data_url, status_code=200, reason="OK", text='{"something": "else"}')
 
             with self.app.app_context():
-                result_data, result_status = sut.get_business_details(ru)
+                sut.get_business_details(ru)
 
-        self.assertEqual(result_data, {"something": "else"})
-        self.assertEqual(result_status, 200)
         self.assertTrue(mock_request.call_count == 2)
 
     @requests_mock.mock()
     def test_results_returned_from_get_business_details_returned_as_expected(self, mock_request):
         """Test get business details sends a request and returns data"""
         ru = "1234"
-        business_data_url = self.app.config['RAS_PARTY_GET_BY_BUSINESS'].\
-            format(self.app.config['RAS_PARTY_SERVICE'], ru)
+        business_data_url = self.app.config['RAS_PARTY_GET_BY_BUSINESS'].format(self.app.config['RAS_PARTY_SERVICE'], ru)
         mock_request.get(business_data_url, status_code=200, reason="OK", text='{"something": "else"}')
         sut = PartyService()
 
@@ -87,8 +74,7 @@ class PartyTestCase(unittest.TestCase):
     def test_get_business_details_converts_error_list_to_errors_dictionary(self, mock_request):
         """Test get business details and returns correctly from a list"""
         ru = "1234"
-        business_data_url = self.app.config['RAS_PARTY_GET_BY_BUSINESS'].\
-            format(self.app.config['RAS_PARTY_SERVICE'], ru)
+        business_data_url = self.app.config['RAS_PARTY_GET_BY_BUSINESS'].format(self.app.config['RAS_PARTY_SERVICE'], ru)
         sut = PartyService()
         mock_request.get(business_data_url, status_code=200, reason="OK", text='[{"errors": "test"}]')
 
@@ -102,8 +88,7 @@ class PartyTestCase(unittest.TestCase):
     def test_get_business_details_fails(self, mock_request):
         """Test get business details and returns correctly from a list"""
         ru = "1234"
-        business_data_url = self.app.config['RAS_PARTY_GET_BY_BUSINESS'].\
-            format(self.app.config['RAS_PARTY_SERVICE'], ru)
+        business_data_url = self.app.config['RAS_PARTY_GET_BY_BUSINESS'].format(self.app.config['RAS_PARTY_SERVICE'], ru)
         sut = PartyService()
         mock_request.get(business_data_url, status_code=401, reason="unauthorised", text='Unauthorized Access')
 
@@ -140,8 +125,7 @@ class PartyTestCase(unittest.TestCase):
     def test_get_user_details_calls_party_service_for_respondent(self, mock_request):
         """Test get user details sends a request and receives back data"""
         sut = PartyService()
-        user_data_url = self.app.config['RAS_PARTY_GET_BY_RESPONDENT'].\
-            format(self.app.config['RAS_PARTY_SERVICE'], 'NotBres')
+        user_data_url = self.app.config['RAS_PARTY_GET_BY_RESPONDENT'].format(self.app.config['RAS_PARTY_SERVICE'], 'NotBres')
         mock_request.get(user_data_url, status_code=200, reason="OK", text='{"Test": "test"}')
 
         with self.app.app_context():
@@ -154,8 +138,7 @@ class PartyTestCase(unittest.TestCase):
     def test_get_user_details_calls_party_service_for_respondent_unauthorised(self, mock_request):
         """Test get user details sends a request and receives back data"""
         sut = PartyService()
-        user_data_url = self.app.config['RAS_PARTY_GET_BY_RESPONDENT'].\
-            format(self.app.config['RAS_PARTY_SERVICE'], 'NotBres')
+        user_data_url = self.app.config['RAS_PARTY_GET_BY_RESPONDENT'].format(self.app.config['RAS_PARTY_SERVICE'], 'NotBres')
         mock_request.get(user_data_url, status_code=401, reason="unauthorised", text="Unauthorized access")
 
         with self.app.app_context():


### PR DESCRIPTION
… request.

**What is the context of this PR?**

Link to Trello card : https://trello.com/c/EJbRooMU/29-use-local-per-request-cache-in-classes-that-interface-to-external-services-3

In party service I have stored the the uuid and the ru for each request, so that if the call for that specific id has been done, the stored party_data will be returned without calling the real service. 


**How to review**

Any notes for the reviewer  (include screenshots if appropriate).
