### PR TITLE
Update logger to use stdout streaming

### DIFF
--- a/secure_message/logger_config.py
+++ b/secure_message/logger_config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 
 from structlog import configure
 from structlog.stdlib import add_log_level, filter_by_level
@@ -33,7 +34,8 @@ def logger_initial_config(service_name=None,
         event_dict['service'] = service_name
         return event_dict
 
-    logging.basicConfig(level=log_level,
+    logging.basicConfig(stream=sys.stdout,
+                        level=log_level,
                         format=logger_format)
     configure(processors=[add_log_level,
                           filter_by_level,

--- a/tests/app/test_logging.py
+++ b/tests/app/test_logging.py
@@ -35,12 +35,5 @@ class LoggingTestCase(unittest.TestCase):
         output = out.getvalue().strip()
         self.assertIsNotNone(output)
 
-    def test_basic_logger_config(self):
-        """Test logger configuration"""
-        with mock.patch('logging.basicConfig') as loggingConfig:
-            logger_initial_config(service_name='ras-secure-message', log_level='INFO', logger_format="message", logger_date_format='2017-06-13')
-            loggingConfig.assert_called_with(level='INFO', format="message")
-
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**What is the context of this PR?**

Set logger to use stdout for streaming in logger config. This will stop cloudfoundry logging all application logs at stderr.

Link to Trello card
https://trello.com/c/RW1t6CDZ

Describe what you have changed and why, link to other PRs or Issues as appropriate.

Added stream as a parameter for logging basic config in the logger config and passed stdout to stop the default stderr being used.

**How to review**

Currently deployed in test environment so hitting any the endpoint should show the logs no longer being stderr.

Any notes for the reviewer  (include screenshots if appropriate).
