### PR TITLE
Added sql script to change secure_message to have a from_internal col…

### DIFF
--- a/sql-scripts/adding_from_internal_to_secure_message.sql
+++ b/sql-scripts/adding_from_internal_to_secure_message.sql
@@ -1,0 +1,15 @@
+-- Script to add a from_internal column to secure_message
+-- and populate from_internal to true
+-- for messages that were sent from internal as bres user
+-- Also drops the internal_sent_audit table and actors tables if present
+
+
+Alter table securemessage.secure_message ADD from_internal Bool Default False;
+
+update securemessage.secure_message m
+set from_internal = true
+where m.msg_id in (select s.msg_id from securemessage.status s where s.actor = 'BRES' and s.label='SENT');
+
+
+DROP TABLE IF EXISTS securemessage.internal_sent_audit;
+DROP TABLE IF EXISTS securemessage.actors;


### PR DESCRIPTION
The latest push of secure message to master will break the existing environments . It will do this as it is expecting from_internal column on secure_message table . 

https://trello.com/c/xVJJz4xK
Describe what you have changed and why, link to other PRs or Issues as appropriate.

Created script and tested locally to
Add from_internal column to secure_message
default to false , set true if sent by BRES
Also Drop sent_from_internal table and actors table if they exist 
