### PR TITLE
internal_user_service returns constant data when a user is defined as…

### DIFF
--- a/secure_message/api_mocks/internal_user_service_mock.py
+++ b/secure_message/api_mocks/internal_user_service_mock.py
@@ -1,4 +1,6 @@
 import logging
+from secure_message.constants import BRES_USER, NON_SPECIFIC_INTERNAL_USER
+from secure_message.services.internal_user_service import InternalUserService
 
 from structlog import wrap_logger
 
@@ -50,6 +52,8 @@ class InternalUserServiceMock:
         """gets the user details from the internal user service"""
         found = None
         if uuid:
+            if uuid in [NON_SPECIFIC_INTERNAL_USER, BRES_USER]:
+                return InternalUserService._get_non_specific_user_details(uuid)
             found = self.internal_user_dict.get(uuid)
             if not found:
                 err_string = f"error retrieving details for {uuid}"

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -18,6 +18,7 @@ from secure_message.repository.retriever import Retriever
 from secure_message.repository.saver import Saver
 from secure_message.resources.drafts import DraftModifyById
 from secure_message.services.service_toggles import party, case_service, internal_user_service
+
 from secure_message.validation.domain import MessageSchema
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -145,18 +146,19 @@ class MessageSend(Resource):
 
     @staticmethod
     def _get_user_name(user, message):
-        user_name = 'Unknown user'
-        if message.msg_from == constants.BRES_USER:
-            user_name = constants.BRES_USER
-        else:
-            user_data = internal_user_service.get_user_details(message.msg_from) if user.is_internal else party.get_user_details(message.msg_from)
 
-            if user_data:
-                first_name = user_data.get('firstName', '')
-                last_name = user_data.get('lastName', '')
-                full_name = f'{first_name} {last_name}'.strip()
-                if full_name:
-                    user_name = full_name
+        if message.msg_from == constants.BRES_USER:
+            return constants.BRES_USER
+
+        user_name = 'Unknown user'
+        user_data = internal_user_service.get_user_details(message.msg_from) if user.is_internal else party.get_user_details(message.msg_from)
+
+        if user_data:
+            first_name = user_data.get('firstName', '')
+            last_name = user_data.get('lastName', '')
+            full_name = f'{first_name} {last_name}'.strip()
+            if full_name:
+                user_name = full_name
 
         return user_name
 

--- a/secure_message/services/internal_user_service.py
+++ b/secure_message/services/internal_user_service.py
@@ -5,6 +5,8 @@ import requests
 from requests import HTTPError
 from structlog import wrap_logger
 
+from secure_message.constants import NON_SPECIFIC_INTERNAL_USER, BRES_USER
+
 logger = wrap_logger(logging.getLogger(__name__))
 
 
@@ -12,6 +14,9 @@ class InternalUserService:
     @staticmethod
     def get_user_details(uuid):
         """gets the user details from the internal user service"""
+        if uuid in [NON_SPECIFIC_INTERNAL_USER, BRES_USER]:
+            return InternalUserService._get_non_specific_user_details(uuid)
+
         logger.info("Getting user details from uaa", uuid=uuid)
         url = f"{current_app.config['UAA_URL']}/Users/{uuid}"
         uaa_token = current_app.oauth_client_token
@@ -42,3 +47,19 @@ class InternalUserService:
         except KeyError:
             logger.exception("UAA didn't return all expected details", uuid=uuid)
             raise
+
+    @staticmethod
+    def _get_non_specific_user_details(group):
+        if group == NON_SPECIFIC_INTERNAL_USER:
+            return {
+                "id": NON_SPECIFIC_INTERNAL_USER,
+                "firstName": "Ons user",
+                "lastName": "",
+                "emailAddress": ""
+            }
+        else:
+            return {"id": BRES_USER,
+                    "firstName": "BRES",
+                    "lastName": "",
+                    "emailAddress": ""
+                    }

--- a/tests/app/test_internal_user_service.py
+++ b/tests/app/test_internal_user_service.py
@@ -1,0 +1,51 @@
+import unittest
+
+from secure_message import constants
+from secure_message.application import create_app
+from secure_message.services.internal_user_service import InternalUserService
+
+
+class PartyBusinessTestHelper:
+    def __init__(self, status_code, reason, text):
+        self.status_code = status_code
+        self.reason = reason
+        self.text = text
+
+
+class InternalUserServiceTestCase(unittest.TestCase):
+    """Test cases for internal user service"""
+
+    def setUp(self):
+        """setup test environment"""
+        self.app = create_app()
+        self.app.testing = True
+
+    def test_results_default_information_returned_for_bres_user(self):
+        """Test get business details sends a request and returns data"""
+
+        sut = InternalUserService()
+        expected = {"id": constants.BRES_USER,
+                    "firstName": "BRES",
+                    "lastName": "",
+                    "emailAddress": ""
+                    }
+        actual = sut.get_user_details(constants.BRES_USER)
+
+        self.assertEqual(expected, actual)
+
+    def test_results_default_information_returned_for_group_user(self):
+        """Test get business details sends a request and returns data"""
+
+        sut = InternalUserService()
+        expected = {"id": constants.NON_SPECIFIC_INTERNAL_USER,
+                    "firstName": "Ons user",
+                    "lastName": "",
+                    "emailAddress": ""
+                    }
+        actual = sut.get_user_details(constants.NON_SPECIFIC_INTERNAL_USER)
+
+        self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/app/test_mock_party.py
+++ b/tests/app/test_mock_party.py
@@ -66,10 +66,11 @@ class PartyTestCase(unittest.TestCase):
                                                 'lastName': 'Oorschot',
                                                 'sampleUnitType': 'BI'
                                                 })
+
         self.assertEqual(message['@msg_to'], [{"id": "BRES",
                                                "firstName": "BRES",
                                                "lastName": "",
-                                               "emailAddress": "mock@email.com"
+                                               "emailAddress": ""
                                                }])
 
     def test_messages_get_replaces_uuids_with_user_details(self):
@@ -173,7 +174,7 @@ class PartyTestCase(unittest.TestCase):
             self.assertEqual(draft['@msg_to'][0], {"id": constants.BRES_USER,
                                                    "firstName": "BRES",
                                                    "lastName": "",
-                                                   "emailAddress": "mock@email.com"})
+                                                   "emailAddress": ""})
 
     def test_get_business_details_by_ru(self):
         """Test get details for one business using ru_id"""

--- a/tests/behavioural/features/steps/to_field.py
+++ b/tests/behavioural/features/steps/to_field.py
@@ -2,6 +2,7 @@ import nose.tools
 from behave import given, then, when
 from flask import json
 from secure_message import constants
+from secure_message.constants import BRES_USER, NON_SPECIFIC_INTERNAL_USER
 
 
 @given("the to is set to '{msg_to}'")
@@ -80,3 +81,48 @@ def step_impl_the_msg_to_is_set_to_internal_group_user(context):
 def step_impl_the_msg_to_is_set_to_internal_specific_user(context):
     """ set the msg to field in the message data to the specific internal user as specified in the helper"""
     step_impl_the_msg_to_is_set_to(context, context.bdd_helper.internal_id_specific_user)
+
+
+@then("the at_msg_to is set correctly for internal group")
+def step_impl_the_at_msg_to_is_set_to_internal_group_user(context):
+    msg_resp = json.loads(context.response.data)
+    expected = {"id": NON_SPECIFIC_INTERNAL_USER,
+                "firstName": "Ons user",
+                "lastName": "",
+                "emailAddress": ""
+                }
+    nose.tools.assert_equal(msg_resp['@msg_to'][0], expected)
+
+
+@then("the at_msg_to is set correctly for bres user")
+def step_impl_the_at_msg_to_is_set_to_bres_user(context):
+    msg_resp = json.loads(context.response.data)
+    expected = {"id": BRES_USER,
+                "firstName": "BRES",
+                "lastName": "",
+                "emailAddress": ""
+                }
+    nose.tools.assert_equal(msg_resp['@msg_to'][0], expected)
+
+
+@then("the at_msg_to is set correctly for internal group for all messages")
+def step_impl_the_at_msg_to_is_set_to_internal_group_user_for_all_messages(context):
+
+    expected = {"id": NON_SPECIFIC_INTERNAL_USER,
+                "firstName": "Ons user",
+                "lastName": "",
+                "emailAddress": ""
+                }
+    for msg in context.bdd_helper.messages_responses_data[0]['messages']:
+        nose.tools.assert_equal(msg['@msg_to'][0], expected)
+
+
+@then("the at_msg_to is set correctly for bres user for all messages")
+def step_impl_the_at_msg_to_is_set_to_bres_user_for_all_messages(context):
+    expected = {"id": BRES_USER,
+                "firstName": "BRES",
+                "lastName": "",
+                "emailAddress": ""
+                }
+    for msg in context.bdd_helper.messages_responses_data[0]['messages']:
+        nose.tools.assert_equal(msg['@msg_to'][0], expected)

--- a/tests/behavioural/features/v2/message_get.feature
+++ b/tests/behavioural/features/v2/message_get.feature
@@ -55,3 +55,17 @@ Feature: Message get by ID Endpoint V2
     |Collection Case      |group         |
     |Collection Exercise  |group         |
     |survey               |group         |
+
+  Scenario: Respondent saves a message to GROUP and retrieves it verify the @msg_to is correctly populated
+    Given sending from respondent to internal group
+      And   the message is sent V2
+      And the message is read V2
+    Then a success status code (200) is returned
+      And the at_msg_to is set correctly for internal group
+
+  Scenario: Respondent saves a message to BRES and retrieves itge verify the @msg_to is correctly populated
+    Given sending from respondent to internal bres user
+      And   the message is sent
+      And the message is read V2
+    Then a success status code (200) is returned
+      And the at_msg_to is set correctly for bres user

--- a/tests/behavioural/features/v2/messages_get.feature
+++ b/tests/behavioural/features/v2/messages_get.feature
@@ -89,3 +89,17 @@ Feature: Get Messages list V2 Endpoint
     | user        |
     | specific user |
     | group        |
+
+  Scenario: Respondent saves a message to GROUP and gets message list verify the @msg_to is correctly populated
+    Given sending from respondent to internal group
+      And   the message is sent V2
+      And messages are read V2
+    Then a success status code (200) is returned
+      And the at_msg_to is set correctly for internal group for all messages
+
+  Scenario: Respondent saves a message to BRES using V1 and gets message list using V2 verify the @msg_to is correctly populated
+    Given sending from respondent to internal group
+      And   the message is sent
+      And messages are read V2
+    Then a success status code (200) is returned
+      And the at_msg_to is set correctly for bres user for all messages


### PR DESCRIPTION

https://trello.com/c/AHtQQz7s

When reading messages sent by a respondent then if the msg_to was set to BRES or GROUP then there were errors as no  @msg_to was being returned to the client. This change detects these in the internal_user_service and returns default information

Changes:

Modified internal_user_service to return constant data if the actor is BRES or GROUP ( BRES needed for old messages) 
Modified internal_user_service_mock to mirror service changes
Added unit tests for this in tests.app.test_internal_user_service
Added Behavioural tests in V2 message_get and messages_get to validate expected values returned in @msg_to
Minor code refactor in messages._get_user_name
Modified test_mock_party since internal_user_service does not return same data as party and this caused some tests to fail.