### PR TITLE
Feature/add filter options to get threads

### DIFF
--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -45,10 +45,9 @@ def get_options(args, draft_only=False):
     if draft_only:
         label = Labels.DRAFT.value
         string_query_args = add_string_query_args(string_query_args, 'label', label)
-    else:
-        if args.get('label'):
-            label = str(args.get('label'))
-            string_query_args = add_string_query_args(string_query_args, 'label', args.get('label'))
+    elif args.get('label'):
+        label = str(args.get('label'))
+        string_query_args = add_string_query_args(string_query_args, 'label', args.get('label'))
     if args.get('ce'):
         ce = str(args.get('ce'))
         string_query_args = add_string_query_args(string_query_args, 'ce', args.get('ce'))

--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -4,6 +4,7 @@ import logging
 
 from flask import jsonify
 from structlog import wrap_logger
+from secure_message.common.labels import Labels
 from secure_message.services.service_toggles import party, internal_user_service
 from secure_message.constants import MESSAGE_BY_ID_ENDPOINT, MESSAGE_LIST_ENDPOINT, MESSAGE_QUERY_LIMIT
 
@@ -13,7 +14,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 MessageArgs = collections.namedtuple('MessageArgs', 'string_query_args page limit ru_id survey cc label desc ce')
 
 
-def get_options(args, label_override=None):
+def get_options(args, draft_only=False):
     """extract options from request , allow label to be set by caller"""
 
     string_query_args = '?'
@@ -41,9 +42,9 @@ def get_options(args, label_override=None):
     if args.get('cc'):
         cc = str(args.get('cc'))
         string_query_args = add_string_query_args(string_query_args, 'cc', args.get('cc'))
-    if label_override:
-        label = label_override
-        string_query_args = add_string_query_args(string_query_args, 'label', label_override)
+    if draft_only:
+        label = Labels.DRAFT.value
+        string_query_args = add_string_query_args(string_query_args, 'label', label)
     else:
         if args.get('label'):
             label = str(args.get('label'))

--- a/secure_message/resources/drafts.py
+++ b/secure_message/resources/drafts.py
@@ -88,7 +88,7 @@ class DraftList(Resource):
     def get():
         """Get message list with options"""
 
-        message_args = get_options(request.args, label_override=Labels.DRAFT.value)
+        message_args = get_options(request.args, draft_only=True)
 
         result = Retriever().retrieve_message_list(g.user, message_args)
 

--- a/secure_message/resources/drafts.py
+++ b/secure_message/resources/drafts.py
@@ -88,13 +88,11 @@ class DraftList(Resource):
     def get():
         """Get message list with options"""
 
-        message_args = get_options(request.args)
+        message_args = get_options(request.args, label_override=Labels.DRAFT.value)
 
-        message_service = Retriever()
-        result = message_service.retrieve_message_list(message_args.page, message_args.limit, g.user, label=Labels.DRAFT.value)
+        result = Retriever().retrieve_message_list(g.user, message_args)
 
-        resp = paginated_list_to_json(result, message_args.page, message_args.limit, request.host_url,
-                                      g.user, message_args.string_query_args, DRAFT_LIST_ENDPOINT)
+        resp = paginated_list_to_json(result, request.host_url, g.user, message_args, DRAFT_LIST_ENDPOINT)
         resp.status_code = 200
         return resp
 

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -36,13 +36,9 @@ class MessageList(Resource):
         message_args = get_options(request.args)
 
         message_service = Retriever()
-        result = message_service.retrieve_message_list(message_args.page, message_args.limit, g.user,
-                                                       ru_id=message_args.ru_id, survey=message_args.survey,
-                                                       cc=message_args.cc, label=message_args.label,
-                                                       descend=message_args.desc, ce=message_args.ce)
+        result = message_service.retrieve_message_list(g.user, message_args)
 
-        return make_response(paginated_list_to_json(result, message_args.page, message_args.limit, request.host_url,
-                                                    g.user, message_args.string_query_args, MESSAGE_LIST_ENDPOINT), 200)
+        return make_response(paginated_list_to_json(result, request.host_url, g.user, message_args, MESSAGE_LIST_ENDPOINT), 200)
 
 
 class MessageSend(Resource):

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -17,7 +17,7 @@ class ThreadById(Resource):
     @staticmethod
     def get(thread_id):
         """Get messages by thread id"""
-        message_args = get_options(request.args)  # NOQA TODO - Named Tuple
+        message_args = get_options(request.args)  # NOQA
 
         conversation = Retriever().retrieve_thread(thread_id, g.user, message_args.page, message_args.limit)
 
@@ -31,10 +31,8 @@ class ThreadList(Resource):
     @staticmethod
     def get():
         """Get thread list"""
-
         message_args = get_options(request.args)
-
-        result = Retriever().retrieve_thread_list(message_args.page, message_args.limit, g.user)
+        result = Retriever().retrieve_thread_list(g.user, message_args)
 
         return make_response(paginated_list_to_json(result, message_args.page, message_args.limit, request.host_url,
                                                     g.user, message_args.string_query_args, THREAD_LIST_ENDPOINT), 200)

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -12,17 +12,16 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 class ThreadById(Resource):
-    """Return list of messages for user"""
+    """Return list of messages in a thread for user"""
 
     @staticmethod
     def get(thread_id):
         """Get messages by thread id"""
-        message_args = get_options(request.args)  # NOQA
+        message_args = get_options(request.args)
 
-        conversation = Retriever().retrieve_thread(thread_id, g.user, message_args.page, message_args.limit)
+        conversation = Retriever().retrieve_thread(thread_id, g.user, message_args)
 
-        return make_response(paginated_list_to_json(conversation, message_args.page, message_args.limit, request.host_url, g.user,
-                             message_args.string_query_args, THREAD_BY_ID_ENDPOINT + "/" + thread_id), 200)
+        return make_response(paginated_list_to_json(conversation, request.host_url, g.user, message_args, THREAD_BY_ID_ENDPOINT + "/" + thread_id), 200)
 
 
 class ThreadList(Resource):
@@ -32,7 +31,7 @@ class ThreadList(Resource):
     def get():
         """Get thread list"""
         message_args = get_options(request.args)
+
         result = Retriever().retrieve_thread_list(g.user, message_args)
 
-        return make_response(paginated_list_to_json(result, message_args.page, message_args.limit, request.host_url,
-                                                    g.user, message_args.string_query_args, THREAD_LIST_ENDPOINT), 200)
+        return make_response(paginated_list_to_json(result, request.host_url, g.user, message_args, THREAD_LIST_ENDPOINT), 200)

--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from flask import g
 
 from secure_message import constants
-from secure_message.services.service_toggles import internal_user_service
+from secure_message.services.service_toggles import internal_user_service, party, case_service
 from secure_message.validation.domain import Message, MessageSchema, DraftSchema
 from secure_message.validation.user import User
 from secure_message.application import create_app
@@ -17,6 +17,9 @@ class MessageTestCase(unittest.TestCase):
     def setUp(self):
         """setup test environment"""
         self.now = datetime.now(timezone.utc)
+        internal_user_service.use_mock_service()
+        case_service.use_mock_service()
+        party.use_mock_service()
 
     def test_message(self):
         """creating Message object"""
@@ -83,6 +86,8 @@ class MessageSchemaTestCase(unittest.TestCase):
                              'thread_id': "", 'ru_id': "7fc0e8ab-189c-4794-b8f4-9f05a1db185b", 'survey': "RSI"}
         self.now = datetime.now(timezone.utc)
         internal_user_service.use_mock_service()
+        case_service.use_mock_service()
+        party.use_mock_service()
         self.app = create_app()
 
     def test_valid_message_passes_validation(self):

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import NotFound, InternalServerError
 
 from secure_message.application import create_app
 from secure_message.common.eventsapi import EventsApi
+from secure_message.common.utilities import MessageArgs
 from secure_message.repository import database
 from secure_message.repository.retriever import Retriever
 from secure_message.constants import MESSAGE_QUERY_LIMIT
@@ -179,6 +180,9 @@ class RetrieverTestCaseHelper:
                 self.add_event(event=EventsApi.DRAFT_SAVED.value, msg_id=msg_id, date_time=datetime(year, month, day + 2))
 
         return threads
+
+    def get_args(self, page=1, limit=100, survey="", cc="", ru="", label="", desc=True, ce=""):
+        return MessageArgs(string_query_args="", page=page, limit=limit, ru_id=ru, survey=survey, cc=cc, label=label, desc=desc, ce=ce)
 
 
 class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
@@ -871,7 +875,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
             self.db.drop_all()
             with current_app.test_request_context():
                 with self.assertRaises(InternalServerError):
-                    Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_respondent)
+                    args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                    Retriever().retrieve_thread_list(self.user_respondent, args)
 
     def test_thread_list_returned_in_descending_order_respondent(self):
         """retrieves threads from database in desc sent_date order for respondent"""
@@ -880,7 +885,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_respondent)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_respondent, args)
 
                 date = []
                 for message in response.items:
@@ -901,7 +907,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_internal)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_internal, args)
 
                 date = []
                 for message in response.items:
@@ -922,7 +929,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_respondent)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_respondent, args)
 
                 date = []
                 for message in response.items:
@@ -943,7 +951,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_internal)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_internal, args)
 
                 date = []
                 for message in response.items:
@@ -964,7 +973,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_internal)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_internal, args)
 
                 date = []
                 thread_ids = []
@@ -993,7 +1003,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_respondent)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_respondent, args)
 
                 date = []
                 thread_ids = []
@@ -1022,7 +1033,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_internal)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_internal, args)
 
                 date = []
                 thread_ids = []
@@ -1051,7 +1063,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_respondent)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_respondent, args)
 
                 date = []
                 thread_ids = []
@@ -1080,7 +1093,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_internal)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_internal, args)
 
                 date = []
                 thread_ids = []
@@ -1109,7 +1123,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_respondent)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_respondent, args)
 
                 date = []
                 thread_ids = []
@@ -1137,8 +1152,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         self.populate_database(5, single=False, multiple_users=True)
 
         with self.app.app_context():
-            with current_app.test_request_context():
-                response = Retriever().retrieve_thread_list(1, MESSAGE_QUERY_LIMIT, self.user_internal)
+                args = self.get_args(limit=MESSAGE_QUERY_LIMIT)
+                response = Retriever().retrieve_thread_list(self.user_internal, args)
 
                 date = []
                 thread_ids = []

--- a/tests/app/test_utilities.py
+++ b/tests/app/test_utilities.py
@@ -1,1 +1,9 @@
+from secure_message.common.utilities import MessageArgs
+
+
 BRES_SURVEY = "33333333-22222-3333-4444-88dc018a1a4c"
+
+
+def get_args(page=1, limit=100, survey="", cc="", ru="", label="", desc=True, ce=""):
+    return MessageArgs(string_query_args="", page=page, limit=limit, ru_id=ru, survey=survey, cc=cc, label=label,
+                       desc=desc, ce=ce)

--- a/tests/behavioural/features/message_put.feature
+++ b/tests/behavioural/features/message_put.feature
@@ -11,6 +11,7 @@ Feature: Checking correct labels for messages are added & deleted
     When  the message labels are modified
       And  the message is read
     Then the response message has the label 'ARCHIVE'
+      And a success status code (200) is returned
 
   Scenario: An internal user modifies the archive status or a message to archived
     Given sending from internal bres user to respondent
@@ -20,6 +21,7 @@ Feature: Checking correct labels for messages are added & deleted
     When  the message labels are modified
       And  the message is read
     Then the response message has the label 'ARCHIVE'
+      And a success status code (200) is returned
 
   Scenario: A Respondent removes an archived status from a message
     Given sending from respondent to internal bres user
@@ -32,6 +34,7 @@ Feature: Checking correct labels for messages are added & deleted
       And  the message labels are modified
       And  the message is read
     Then the response message does not have the label 'ARCHIVE'
+     And a success status code (200) is returned
 
   Scenario: An internal user removes an archived status from a message
     Given sending from internal bres user to respondent
@@ -44,6 +47,7 @@ Feature: Checking correct labels for messages are added & deleted
       And  the message labels are modified
       And  the message is read
     Then the response message does not have the label 'ARCHIVE'
+     And a success status code (200) is returned
 
    Scenario: A respondent sends a message the internal user marks it as READ
     Given sending from respondent to internal bres user
@@ -54,6 +58,7 @@ Feature: Checking correct labels for messages are added & deleted
       And  the message labels are modified
       And  the message is read
      Then the response message does not have the label 'UNREAD'
+      And a success status code (200) is returned
 
   Scenario: An internal user sends a message the internal user marks it as READ
     Given sending from internal bres user to respondent
@@ -64,6 +69,7 @@ Feature: Checking correct labels for messages are added & deleted
       And  the message labels are modified
       And  the message is read
      Then the response message does not have the label 'UNREAD'
+      And a success status code (200) is returned
 
   Scenario: A respondent sends a message the internal user marks it as READ then UNREAD
     Given sending from respondent to internal bres user
@@ -79,6 +85,7 @@ Feature: Checking correct labels for messages are added & deleted
      Then the response message has the label 'UNREAD'
       And the response message has the label 'INBOX'
       And the response message should a label count of '2'
+      And a success status code (200) is returned
 
 
   Scenario: An internal user sends a message the internal user marks it as READ then UNREAD
@@ -95,6 +102,7 @@ Feature: Checking correct labels for messages are added & deleted
      Then the response message has the label 'UNREAD'
       And the response message has the label 'INBOX'
       And the response message should a label count of '2'
+      And a success status code (200) is returned
 
 
 

--- a/tests/behavioural/features/steps/endpoints.py
+++ b/tests/behavioural/features/steps/endpoints.py
@@ -266,6 +266,38 @@ def step_impl_the_threads_are_read(context):
     context.bdd_helper.store_messages_response_data(context.response.data)
 
 
+@when("the threads in survey '{survey}' are read")
+@given("the threads in survey '{survey}' are read")
+def step_impl_the_threads_in_specific_survey_are_returned(context, survey):
+    url = context.bdd_helper.threads_get_url + f"?survey={survey}"
+    context.response = context.app.test_client().get(url, headers=context.bdd_helper.headers)
+    context.bdd_helper.store_messages_response_data(context.response.data)
+
+
+@when("the threads with ru '{ru_id}' are read")
+@given("the threads with ru '{ru_id}' are read")
+def step_impl_the_threads_in_specific_ru_id_are_returned(context, ru_id):
+    url = context.bdd_helper.threads_get_url + f"?ru_id={ru_id}"
+    context.response = context.app.test_client().get(url, headers=context.bdd_helper.headers)
+    context.bdd_helper.store_messages_response_data(context.response.data)
+
+
+@when("the threads with collection case '{cc}' are read")
+@given("the threads with collection case '{cc}' are read")
+def step_impl_the_threads_in_specific_collection_case_id_are_returned(context, cc):
+    url = context.bdd_helper.threads_get_url + f"?cc={cc}"
+    context.response = context.app.test_client().get(url, headers=context.bdd_helper.headers)
+    context.bdd_helper.store_messages_response_data(context.response.data)
+
+
+@when("the threads with collection exercise '{ce}' are read")
+@given("the threads with collection exercise '{ce}' are read")
+def step_impl_the_threads_in_specific_collection_case_exercise_are_returned(context, ce):
+    url = context.bdd_helper.threads_get_url + f"?ce={ce}"
+    context.response = context.app.test_client().get(url, headers=context.bdd_helper.headers)
+    context.bdd_helper.store_messages_response_data(context.response.data)
+
+
 @when("user accesses the /draft/save endpoint with using the PUT method")
 def step_impl_access_endpoint_with_wrong_method(context):
     context.bdd_helper.sent_messages.extend([context.bdd_helper.message_data])
@@ -416,7 +448,7 @@ def step_impl_messages_are_read_with_specific_label_using_v2(context, label_name
 
 @when("the count of  messages with '{label_name}' label in survey '{survey}' is made V2")
 @given("the count of  messages with '{label_name}' label in survey '{survey}' is made V2")
-def step_impl_the_unread_messages_are_counted_for_survey(context, label_name, survey):
+def step_impl_the_messages_for_specific_survey_are_counted_for_survey(context, label_name, survey):
     """access the messages_count endpoint to get the count of unread messages"""
     url = context.bdd_helper.messages_get_unread_count_v2_url + "?label={}&survey={}".format(label_name, survey)
     context.response = context.app.test_client().get(url, headers=context.bdd_helper.headers)

--- a/tests/behavioural/features/steps/ru_field.py
+++ b/tests/behavioural/features/steps/ru_field.py
@@ -7,7 +7,7 @@ from flask import json
 @when("the ru is set to '{ru}'")
 def step_impl_the_ru_is_set_to(context, ru):
     """set the message data ru to a specific value"""
-    context.bdd_helper.message_data['ru'] = ru
+    context.bdd_helper.message_data['ru_id'] = ru
 
 
 @then("retrieved message ru is as was saved")

--- a/tests/behavioural/features/threads_get.feature
+++ b/tests/behavioural/features/threads_get.feature
@@ -119,3 +119,5 @@ Feature: Get threads list Endpoint
 
 
 
+
+

--- a/tests/behavioural/features/v2/message_put.feature
+++ b/tests/behavioural/features/v2/message_put.feature
@@ -17,6 +17,7 @@ Feature: Checking correct labels for messages are added & deleted V2
      Then the response message has the label 'UNREAD'
       And the response message has the label 'INBOX'
       And the response message should a label count of '2'
+      And a success status code (200) is returned
 
     Examples: user type
     | user        |

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -148,5 +148,253 @@ Feature: Get threads list Endpoint V2
     | specific user |
     | group        |
 
+  Scenario Outline: There are 3 conversations between an internal user and respondent each with 2  messages ,
+                    each with different survey_id validate , that only 2 messages returned when we restrict by survey
+
+    Given sending from internal <user> to respondent
+      And the survey is set to 'Survey1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the survey is set to 'Survey2'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the survey is set to 'Survey1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+    When the threads in survey 'Survey1' are read
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
 
 
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
+
+  Scenario Outline: There are 3 conversations between an respondent and internal user each with 2  messages ,
+                    each with different survey_id validate , that only 2 messages returned when we restrict by survey
+
+    Given sending from respondent to internal <user>
+      And the survey is set to 'Survey1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the survey is set to 'Survey2'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the survey is set to 'Survey1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+    When the threads in survey 'Survey1' are read
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
+
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
+
+  Scenario Outline: There are 3 conversations between an internal user and respondent each with 2  messages ,
+                    each with different ru validate , that only 2 messages returned when we restrict by ru
+
+    Given sending from internal <user> to respondent
+      And the ru is set to 'ru1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the ru is set to 'ru2'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the ru is set to 'ru1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+    When the threads with ru 'ru1' are read
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
+
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
+
+  Scenario Outline: There are 3 conversations between an respondent and internal user each with 2  messages ,
+                    each with different ru validate , that only 2 messages returned when we restrict by ru
+
+    Given sending from respondent to internal <user>
+      And the ru is set to 'ru1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the ru is set to 'ru2'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the ru is set to 'ru1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+    When the threads with ru 'ru1' are read
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
+
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
+  Scenario Outline: There are 3 conversations between an internal user and respondent each with 2  messages ,
+                    each with different collection case validate , that only 2 messages returned when we restrict by collection case
+
+    Given sending from internal <user> to respondent
+      And the collection case is set to 'col1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the collection case is set to 'col2'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the collection case is set to 'col1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+    When the threads with collection case 'col1' are read
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
+
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
+
+  Scenario Outline: There are 3 conversations between an respondent and internal user each with 2  messages ,
+                    each with different collection case validate , that only 2 messages returned when we restrict by collection case
+
+    Given sending from respondent to internal <user>
+      And the collection case is set to 'col1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the collection case is set to 'col2'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the collection case is set to 'col1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+    When the threads with collection case 'col1' are read
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
+
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
+
+ Scenario Outline: There are 3 conversations between an internal user and respondent each with 2  messages ,
+                    each with different collection exercise validate , that only 2 messages returned when we restrict by collection exercise
+
+    Given sending from internal <user> to respondent
+      And the collection_exercise is set to 'ce1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the collection_exercise is set to 'ce2'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the collection_exercise is set to 'ce1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+    When the threads with collection exercise 'ce1' are read
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
+
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
+
+  Scenario Outline: There are 3 conversations between an respondent and internal user each with 2  messages ,
+                    each with different collection exercise validate , that only 2 messages returned when we restrict by collection exercise
+
+    Given sending from respondent to internal <user>
+      And the collection_exercise is set to 'ce1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the collection_exercise is set to 'ce2'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+
+      And the thread_id is set to empty
+      And the collection_exercise is set to 'ce1'
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the message is sent V2
+    When the threads with collection exercise 'ce1' are read
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
+
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |


### PR DESCRIPTION
Currently the get threads endpoint does not support the ability to filter the selection by any parameters , we need to be able to filter by survey in order that we can view the conversations related to a survey.

https://trello.com/c/gfaiP90r

This only covers the ability to filter by survey , ru etc . It does not include the ability to indicate if a thread has an unread message.

Have modified the get threads to use the message args ( survey, ru , collection case etc) 
Have cleaned up request args passing by making more functions use the MessageArgs and not rely on hard to read individual parameters 
Added tests for the same 

