### PR TITLE
Default user details if they're not in the UAA

### DIFF
--- a/secure_message/services/internal_user_service.py
+++ b/secure_message/services/internal_user_service.py
@@ -45,28 +45,25 @@ class InternalUserService:
             logger.info("Successfully retrieved and formatted user details", uuid=uuid)
             return user_details
         except KeyError:
-            user_details = {
-                "id": uuid,
-                "firstName": "ONS",
-                "lastName": "User",
-                "emailAddress": "N/A"
-            }
+            user_details = InternalUserService._get_default_user(uuid)
             logger.exception("UAA didn't return all expected details", uuid=uuid, uaa_resp=resp_json)
 
             return user_details
 
-            logger.exception("UAA didn't return all expected details", uuid=uuid)
-            raise
+    @staticmethod
+    def _get_default_user(uuid):
+        user_details = {
+            "id": uuid,
+            "firstName": "ONS",
+            "lastName": "User",
+            "emailAddress": "N/A"
+        }
+        return user_details
 
     @staticmethod
     def _get_non_specific_user_details(group):
         if group == NON_SPECIFIC_INTERNAL_USER:
-            return {
-                "id": NON_SPECIFIC_INTERNAL_USER,
-                "firstName": "ONS",
-                "lastName": "User",
-                "emailAddress": "N/A"
-            }
+            return InternalUserService._get_default_user(NON_SPECIFIC_INTERNAL_USER)
         else:
             return {"id": BRES_USER,
                     "firstName": "BRES",

--- a/secure_message/services/internal_user_service.py
+++ b/secure_message/services/internal_user_service.py
@@ -45,6 +45,16 @@ class InternalUserService:
             logger.info("Successfully retrieved and formatted user details", uuid=uuid)
             return user_details
         except KeyError:
+            user_details = {
+                "id": uuid,
+                "firstName": "ONS",
+                "lastName": "User",
+                "emailAddress": "N/A"
+            }
+            logger.exception("UAA didn't return all expected details", uuid=uuid, uaa_resp=resp_json)
+
+            return user_details
+
             logger.exception("UAA didn't return all expected details", uuid=uuid)
             raise
 
@@ -53,9 +63,9 @@ class InternalUserService:
         if group == NON_SPECIFIC_INTERNAL_USER:
             return {
                 "id": NON_SPECIFIC_INTERNAL_USER,
-                "firstName": "Ons user",
-                "lastName": "",
-                "emailAddress": ""
+                "firstName": "ONS",
+                "lastName": "User",
+                "emailAddress": "N/A"
             }
         else:
             return {"id": BRES_USER,

--- a/secure_message/services/internal_user_service.py
+++ b/secure_message/services/internal_user_service.py
@@ -46,7 +46,7 @@ class InternalUserService:
             return user_details
         except KeyError:
             user_details = InternalUserService._get_default_user(uuid)
-            logger.exception("UAA didn't return all expected details", uuid=uuid, uaa_resp=resp_json)
+            logger.exception("UAA didn't return all expected details", uuid=uuid)
 
             return user_details
 

--- a/secure_message/services/internal_user_service.py
+++ b/secure_message/services/internal_user_service.py
@@ -56,7 +56,7 @@ class InternalUserService:
             "id": uuid,
             "firstName": "ONS",
             "lastName": "User",
-            "emailAddress": "N/A"
+            "emailAddress": ""
         }
         return user_details
 

--- a/tests/app/test_internal_user_service.py
+++ b/tests/app/test_internal_user_service.py
@@ -34,7 +34,7 @@ class InternalUserServiceTestCase(unittest.TestCase):
         expected = {"id": constants.NON_SPECIFIC_INTERNAL_USER,
                     "firstName": "ONS",
                     "lastName": "User",
-                    "emailAddress": "N/A"
+                    "emailAddress": ""
                     }
         actual = sut.get_user_details(constants.NON_SPECIFIC_INTERNAL_USER)
 

--- a/tests/app/test_internal_user_service.py
+++ b/tests/app/test_internal_user_service.py
@@ -1,7 +1,6 @@
 import unittest
 
 from secure_message import constants
-from secure_message.application import create_app
 from secure_message.services.internal_user_service import InternalUserService
 
 
@@ -14,11 +13,6 @@ class PartyBusinessTestHelper:
 
 class InternalUserServiceTestCase(unittest.TestCase):
     """Test cases for internal user service"""
-
-    def setUp(self):
-        """setup test environment"""
-        self.app = create_app()
-        self.app.testing = True
 
     def test_results_default_information_returned_for_bres_user(self):
         """Test get business details sends a request and returns data"""

--- a/tests/app/test_internal_user_service.py
+++ b/tests/app/test_internal_user_service.py
@@ -38,9 +38,9 @@ class InternalUserServiceTestCase(unittest.TestCase):
 
         sut = InternalUserService()
         expected = {"id": constants.NON_SPECIFIC_INTERNAL_USER,
-                    "firstName": "Ons user",
-                    "lastName": "",
-                    "emailAddress": ""
+                    "firstName": "ONS",
+                    "lastName": "User",
+                    "emailAddress": "N/A"
                     }
         actual = sut.get_user_details(constants.NON_SPECIFIC_INTERNAL_USER)
 

--- a/tests/behavioural/features/steps/to_field.py
+++ b/tests/behavioural/features/steps/to_field.py
@@ -87,8 +87,8 @@ def step_impl_the_msg_to_is_set_to_internal_specific_user(context):
 def step_impl_the_at_msg_to_is_set_to_internal_group_user(context):
     msg_resp = json.loads(context.response.data)
     expected = {"id": NON_SPECIFIC_INTERNAL_USER,
-                "firstName": "Ons user",
-                "lastName": "",
+                "firstName": "ONS",
+                "lastName": "User",
                 "emailAddress": ""
                 }
     nose.tools.assert_equal(msg_resp['@msg_to'][0], expected)
@@ -109,8 +109,8 @@ def step_impl_the_at_msg_to_is_set_to_bres_user(context):
 def step_impl_the_at_msg_to_is_set_to_internal_group_user_for_all_messages(context):
 
     expected = {"id": NON_SPECIFIC_INTERNAL_USER,
-                "firstName": "Ons user",
-                "lastName": "",
+                "firstName": "ONS",
+                "lastName": "User",
                 "emailAddress": ""
                 }
     for msg in context.bdd_helper.messages_responses_data[0]['messages']:


### PR DESCRIPTION
The ras-rm-docker-dev setup has a bootstrapped user. This user 'uaa_user' does not have a given or family name so therefore secure messaging fails with a key error.

In this scenario return a default user of ONS