### PR TITLE
Added tests for retrieving a thread or draft when the returned message is a draft and with no 'to' field set. 

### DIFF
--- a/secure_message/application.py
+++ b/secure_message/application.py
@@ -158,6 +158,7 @@ def get_client_token(client_id, client_secret, url):
         sleep(10)
         return get_client_token(client_id, client_secret, url)
 
+
 def retry_if_database_error(exception):
     logger.error('Database error has occurred', error=exception)
     return isinstance(exception, DatabaseError) and not isinstance(exception, ProgrammingError)

--- a/tests/behavioural/features/draft_get.feature
+++ b/tests/behavioural/features/draft_get.feature
@@ -64,4 +64,17 @@ Feature: Get draft by id
       And  the draft is read
     Then  a forbidden status code (403) is returned
 
+  Scenario: Respondent saves a draft with an empty to field then reads it , should receive a 200
+    Given sending from respondent to internal bres user
+      And  the to is set to empty
+    When the message is saved as draft
+      And the draft is read
+    Then a success status code (200) is returned
+
+  Scenario: Internal user saves a draft with an empty to field then reads it , should receive a 200
+    Given sending from internal bres user to respondent
+      And  the to is set to empty
+    When the message is saved as draft
+      And the draft is read
+    Then a success status code (200) is returned
 

--- a/tests/behavioural/features/steps/endpoints.py
+++ b/tests/behavioural/features/steps/endpoints.py
@@ -3,7 +3,7 @@ from flask import json
 import copy
 
 
-# These steps genrate http requests and responses
+# These steps generate http requests and responses
 
 @given("the message is sent")
 @when("the message is sent")

--- a/tests/behavioural/features/threads_get.feature
+++ b/tests/behavioural/features/threads_get.feature
@@ -116,8 +116,3 @@ Feature: Get threads list Endpoint
       And  '3' messages are returned
       # Drafts added last
       And '3' messages have a 'DRAFT' label
-
-
-
-
-

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -398,3 +398,37 @@ Feature: Get threads list Endpoint V2
     | user        |
     | specific user |
     | group        |
+
+
+  Scenario Outline: There is a conversation between respondent and internal the last message is a draft with an empty to field ,
+                    respondent attempts to read them, should receive  a 200
+    Given sending from respondent to internal <user>
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the to is set to empty
+      And the message is saved as draft V2
+   When the threads are read
+    Then  a success status code (200) is returned
+      And '1' messages are returned
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
+
+  Scenario Outline: There is a conversation between internal and respondent the last message is a draft with an empty to field ,
+                    respondent attempts to read them, should receive  a 200
+    Given sending from internal <user> to respondent
+      And the message is sent V2
+      And the thread id is set to the last returned thread id
+      And the to is set to empty
+      And the message is saved as draft V2
+   When the threads are read
+    Then  a success status code (200) is returned
+      And '1' messages are returned
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |


### PR DESCRIPTION
SM111 is showing the threads , this means it displays the last message in a conversation which may be a draft. There were no tests to prove there would be no issues in the API if there was no 'to' specified. 
