### PR TITLE
Make linting part of testing and enable on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ install:
     - pipenv install --dev --deploy
 
 script:
-    - pipenv run coverage run run_tests.py
+    - make test
+    - pipenv run coverage
 
 services:
     - postgresql

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ lint:
 	pipenv check ./secure_message ./tests
 
 test: lint
-	pipenv run run_tests.py
+	pipenv run python run_tests.py

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ lint:
 	pipenv check ./secure_message ./tests
 
 test: lint
-    pipenv run run_tests.py
+	pipenv run run_tests.py

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ build:
 start:
 	pipenv run python run.py
 
-test:
-	pipenv check --style ./secure_message ./tests
-	pipenv run pytest
+lint:
+	pipenv run flake8 ./secure_message ./tests
+	pipenv check ./secure_message ./tests
+
+test: lint
+    pipenv run run_tests.py

--- a/secure_message/application.py
+++ b/secure_message/application.py
@@ -158,6 +158,7 @@ def get_client_token(client_id, client_secret, url):
         sleep(10)
         return get_client_token(client_id, client_secret, url)
 
+
 def retry_if_database_error(exception):
     logger.error('Database error has occurred', error=exception)
     return isinstance(exception, DatabaseError) and not isinstance(exception, ProgrammingError)


### PR DESCRIPTION
This pull request enables linting on Travis. This has been done via the make targets so there is consistency between running the commands locally and on Travis.

The pipenv --style option has been deprecated (https://github.com/pypa/pipenv/blob/master/HISTORY.txt#L66) so this pull request also uses flake8 explicitly.

**How to review**

- Run make lint locally, it should run successfully
- Verify Travis runs the linting

**Note**: Travis will fail until #169 merges as the `pipenv check` command is now being run properly and finds security vulnerabilities.