### PR TITLE
Bug/fix thread endpoint cutting off body

### DIFF
--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -66,7 +66,7 @@ def add_string_query_args(string_query_args, arg, val):
     return f'{string_query_args}&{arg}={val}'
 
 
-def paginated_list_to_json(paginated_list, host_url, user, message_args, endpoint=MESSAGE_LIST_ENDPOINT):
+def paginated_list_to_json(paginated_list, host_url, user, message_args, endpoint=MESSAGE_LIST_ENDPOINT, body_summary=True):
     """used to change a pagination object to json format with links"""
     messages = []
     msg_count = 0
@@ -76,7 +76,7 @@ def paginated_list_to_json(paginated_list, host_url, user, message_args, endpoin
 
     for message in paginated_list.items:
         msg_count += 1
-        msg = message.serialize(user, body_summary=True)
+        msg = message.serialize(user, body_summary=body_summary)
         msg['_links'] = {"self": {"href": f"{host_url}{MESSAGE_BY_ID_ENDPOINT}/{msg['msg_id']}"}}
         messages.append(msg)
 

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -23,7 +23,14 @@ class ThreadById(Resource):
         conversation = Retriever().retrieve_thread(thread_id, g.user, message_args)
 
         logger.info("Successfully retrieved messages from thread", thread_id=thread_id, user_uuid=g.user.user_uuid)
-        return make_response(paginated_list_to_json(conversation, request.host_url, g.user, message_args, THREAD_BY_ID_ENDPOINT + "/" + thread_id), 200)
+        return make_response(paginated_list_to_json(conversation,
+                                                    request.host_url,
+                                                    g.user,
+                                                    message_args,
+                                                    THREAD_BY_ID_ENDPOINT + "/" + thread_id,
+                                                    body_summary=False),
+
+                             200)
 
 
 class ThreadList(Resource):

--- a/tests/behavioural/features/messages_get.feature
+++ b/tests/behavioural/features/messages_get.feature
@@ -215,3 +215,5 @@ Feature: Get Messages list Endpoint
     When messages are read
       Then a success status code (200) is returned
       And '0' messages are returned with sent from internal
+
+  Scenario: An internal user sends a long message, the respondent views their inbox and sees a 100 character summary of the body

--- a/tests/behavioural/features/messages_get.feature
+++ b/tests/behavioural/features/messages_get.feature
@@ -215,3 +215,10 @@ Feature: Get Messages list Endpoint
     When messages are read
       Then a success status code (200) is returned
       And '0' messages are returned with sent from internal
+
+  Scenario: An internal user sends a very long message, the respondent sees a 100 character summary in their inbox
+    Given sending from internal bres user to respondent
+      And the message body is '5000' characters long
+      And '1' messages are sent
+    When messages are read
+    Then the message bodies are 100 characters or less

--- a/tests/behavioural/features/messages_get.feature
+++ b/tests/behavioural/features/messages_get.feature
@@ -221,4 +221,4 @@ Feature: Get Messages list Endpoint
       And the message body is '5000' characters long
       And '1' messages are sent
     When messages are read
-    Then the message bodies are 100 characters or less
+    Then the message bodies are '100' characters or less

--- a/tests/behavioural/features/messages_get.feature
+++ b/tests/behavioural/features/messages_get.feature
@@ -215,5 +215,3 @@ Feature: Get Messages list Endpoint
     When messages are read
       Then a success status code (200) is returned
       And '0' messages are returned with sent from internal
-
-  Scenario: An internal user sends a long message, the respondent views their inbox and sees a 100 character summary of the body

--- a/tests/behavioural/features/steps/body_field.py
+++ b/tests/behavioural/features/steps/body_field.py
@@ -31,8 +31,21 @@ def step_impl_the_msg_body_is_set_too_long(context):
     context.bdd_helper.message_data['body'] = "x" * (constants.MAX_BODY_LEN + 1)
 
 
+@given("the message body is '{body_length}' characters long")
+def step_impl_the_msg_body_is_set_too_long(context, body_length):
+    """set the body to be body_length characters long"""
+    context.bdd_helper.message_data['body'] = "x" * int(body_length)
+
+
 @then("retrieved message body is as was saved")
 def step_impl_retrieved_body_is_as_saved(context):
-    """validate that the received body was teh same as was sent"""
+    """validate that the received body was the same as was sent"""
     msg_resp = json.loads(context.response.data)
     nose.tools.assert_equal(msg_resp['body'], context.bdd_helper.last_saved_message_data['body'])
+
+
+@then("the threads first message body is as was saved")
+def step_impl_retrieved_body_is_as_saved(context):
+    """validate that the received body of the first message in a thread was the same as was sent"""
+    msg_resp = json.loads(context.response.data)
+    nose.tools.assert_equal(msg_resp['messages'][0]['body'], context.bdd_helper.last_saved_message_data['body'])

--- a/tests/behavioural/features/steps/body_field.py
+++ b/tests/behavioural/features/steps/body_field.py
@@ -32,7 +32,7 @@ def step_impl_the_msg_body_is_set_too_long(context):
 
 
 @given("the message body is '{body_length}' characters long")
-def step_impl_the_msg_body_is_set_too_long(context, body_length):
+def step_impl_the_msg_body_is_length(context, body_length):
     """set the body to be body_length characters long"""
     context.bdd_helper.message_data['body'] = "x" * int(body_length)
 
@@ -45,15 +45,15 @@ def step_impl_retrieved_body_is_as_saved(context):
 
 
 @then("the threads first message body is as was saved")
-def step_impl_retrieved_body_is_as_saved(context):
+def step_impl_first_message_in_thread_is_as_saved(context):
     """validate that the received body of the first message in a thread was the same as was sent"""
     msg_resp = json.loads(context.response.data)
     nose.tools.assert_equal(msg_resp['messages'][0]['body'], context.bdd_helper.last_saved_message_data['body'])
 
 
-@then("the message bodies are 100 characters or less")
-def step_impl_retrieved_bodies_are_100_characters_or_less(context):
-    """validate that the message bodies in a response list are more than 100 characters in length"""
+@then("the message bodies are '{body_length}' characters or less")
+def step_impl_retrieved_bodies_are_100_characters_or_less(context, body_length):
+    """validate that the message bodies in a response list are more than body_length characters in length"""
     msg_resp = json.loads(context.response.data)
     for message in msg_resp['messages']:
-        nose.tools.assert_less_equal(len(message['body']), 100)
+        nose.tools.assert_less_equal(len(message['body']), int(body_length))

--- a/tests/behavioural/features/steps/body_field.py
+++ b/tests/behavioural/features/steps/body_field.py
@@ -49,3 +49,11 @@ def step_impl_retrieved_body_is_as_saved(context):
     """validate that the received body of the first message in a thread was the same as was sent"""
     msg_resp = json.loads(context.response.data)
     nose.tools.assert_equal(msg_resp['messages'][0]['body'], context.bdd_helper.last_saved_message_data['body'])
+
+
+@then("the message bodies are 100 characters or less")
+def step_impl_retrieved_bodies_are_100_characters_or_less(context):
+    """validate that the message bodies in a response list are more than 100 characters in length"""
+    msg_resp = json.loads(context.response.data)
+    for message in msg_resp['messages']:
+        nose.tools.assert_less_equal(len(message['body']), 100)

--- a/tests/behavioural/features/thread_get.feature
+++ b/tests/behavioural/features/thread_get.feature
@@ -104,6 +104,25 @@ Feature: Get thread by id Endpoint
     Then '3' messages are returned
       And '3' messages have a 'SENT' label
 
+  Scenario: Respondent sends a message to internal group, validate the entire message body is received
+    Given sending from respondent to internal group
+      And   the message body is '10000' characters long
+      And   the message is sent
+      And   the user is set as internal
+      And   the from is set to internal group
+      And   the to is set to respondent
+      And   the message is read
+      And   the thread id is set to the last returned thread id
+      And   the message is sent
+      And   the user is set as respondent
+      And   the from is set to respondent
+      And   the to is set to internal group
+      And   the message is read
+      And   the thread id is set to the last returned thread id
+      And   the message is sent
+    When the thread is read
+    Then  a success status code (200) is returned
+      And the threads first message body is as was saved
 
   Scenario:Respondent tries to retrieve a conversation that does not exist
     Given sending from respondent to internal bres user

--- a/tests/behavioural/features/thread_get.feature
+++ b/tests/behavioural/features/thread_get.feature
@@ -104,26 +104,6 @@ Feature: Get thread by id Endpoint
     Then '3' messages are returned
       And '3' messages have a 'SENT' label
 
-  Scenario: Respondent sends a message to internal group, validate the entire message body is received
-    Given sending from respondent to internal group
-      And   the message body is '10000' characters long
-      And   the message is sent
-      And   the user is set as internal
-      And   the from is set to internal group
-      And   the to is set to respondent
-      And   the message is read
-      And   the thread id is set to the last returned thread id
-      And   the message is sent
-      And   the user is set as respondent
-      And   the from is set to respondent
-      And   the to is set to internal group
-      And   the message is read
-      And   the thread id is set to the last returned thread id
-      And   the message is sent
-    When the thread is read
-    Then  a success status code (200) is returned
-      And the threads first message body is as was saved
-
   Scenario:Respondent tries to retrieve a conversation that does not exist
     Given sending from respondent to internal bres user
     When the thread_id is set to 'DoesNotExist'

--- a/tests/behavioural/features/threads_get.feature
+++ b/tests/behavioural/features/threads_get.feature
@@ -122,4 +122,4 @@ Feature: Get threads list Endpoint
       And the message body is '5000' characters long
       And '1' messages are sent
     When the threads are read
-    Then the message bodies are 100 characters or less
+    Then the message bodies are '100' characters or less

--- a/tests/behavioural/features/threads_get.feature
+++ b/tests/behavioural/features/threads_get.feature
@@ -117,7 +117,11 @@ Feature: Get threads list Endpoint
       # Drafts added last
       And '3' messages have a 'DRAFT' label
 
-
-
+  Scenario: A respondent sends a very long message, the internal user sees a 100 character summary in their inbox
+    Given sending from internal bres user to respondent
+      And the message body is '5000' characters long
+      And '1' messages are sent
+    When the threads are read
+    Then the message bodies are 100 characters or less
 
 

--- a/tests/behavioural/features/v2/messages_get.feature
+++ b/tests/behavioural/features/v2/messages_get.feature
@@ -57,6 +57,19 @@ Feature: Get Messages list V2 Endpoint
     | specific user |
     | group        |
 
+
+ Scenario Outline: An internal user sends a very long message, the respondent sees a 100 character summary in their inbox
+    Given sending from internal <user> to respondent
+      And the message body is '5000' characters long
+      And '1' messages are sent using V2
+    When messages are read V2
+    Then the message bodies are 100 characters or less
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |
+
   Scenario Outline: A Respondent sends multiple messages using v2 on different surveys to multiple internal user types ,
                     Internal user reads them without setting a survey confirm correct count seen
     Given sending from respondent to internal <user>

--- a/tests/behavioural/features/v2/messages_get.feature
+++ b/tests/behavioural/features/v2/messages_get.feature
@@ -63,7 +63,7 @@ Feature: Get Messages list V2 Endpoint
       And the message body is '5000' characters long
       And '1' messages are sent using V2
     When messages are read V2
-    Then the message bodies are 100 characters or less
+    Then the message bodies are '100' characters or less
 
     Examples: user type
     | user        |

--- a/tests/behavioural/features/v2/thread_get.feature
+++ b/tests/behavioural/features/v2/thread_get.feature
@@ -47,3 +47,16 @@ Feature: Get thread by id Endpoint V2
     | group        |
 
 
+
+  Scenario Outline: Respondent sends a message to internal group, validate the entire message body is received
+    Given sending from respondent to internal <user>
+      And   the message body is '10000' characters long
+      And   the message is sent
+    When the thread is read
+    Then  a success status code (200) is returned
+      And the threads first message body is as was saved
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -441,4 +441,3 @@ Feature: Get threads list Endpoint V2
     | user        |
     | specific user |
     | group        |
-    | group        |

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -405,7 +405,7 @@ Feature: Get threads list Endpoint V2
       And the message body is '5000' characters long
       And '1' messages are sent using V2
     When the threads are read
-    Then the message bodies are 100 characters or less
+    Then the message bodies are '100' characters or less
 
 
   Scenario Outline: There is a conversation between respondent and internal the last message is a draft with an empty to field ,

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -398,3 +398,17 @@ Feature: Get threads list Endpoint V2
     | user        |
     | specific user |
     | group        |
+
+
+ Scenario Outline: A respondent sends a very long message, the internal user sees a 100 character summary in their inbox
+    Given sending from internal <user> to respondent
+      And the message body is '5000' characters long
+      And '1' messages are sent using V2
+    When the threads are read
+    Then the message bodies are 100 characters or less
+
+
+    Examples: user type
+    | user        |
+    | specific user |
+    | group        |

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -436,7 +436,6 @@ Feature: Get threads list Endpoint V2
     Then  a success status code (200) is returned
       And '1' messages are returned
 
-
     Examples: user type
     | user        |
     | specific user |


### PR DESCRIPTION
**Fix a bug where the thread endpoint was only returning 100 characters of the message body**

Updated the paginated list to json function so that it accepts a keyword argument to summarize the message body (cut it down to 100 characters). It defaults to true since the messages and threads endpoints rely on this to return a summary.

**How to review:**
Run this branch of secure message locally, try sending a long message and then viewing it by the thread by ID endpoint. It should now return the entire message body.
