### PR TITLE
Fix label updating to handle GROUP and internal users

### DIFF
--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -3,11 +3,11 @@ import logging
 from flask import jsonify
 from structlog import wrap_logger
 from werkzeug.exceptions import InternalServerError
+
 from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
 from secure_message.repository.database import db, Status, SecureMessage
 from secure_message.repository.saver import Saver
-from secure_message import constants
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -15,7 +15,6 @@ logger = wrap_logger(logging.getLogger(__name__))
 class Modifier:
     """Modifies message to add / remove statuses"""
 
-
     @staticmethod
     def _get_label_actor(user, message):
         try:

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -5,13 +5,12 @@ from flask_restful import Resource
 from structlog import wrap_logger
 from werkzeug.exceptions import BadRequest
 
-
+from secure_message import constants
 from secure_message.authorization.authorizer import Authorizer
 from secure_message.common.alerts import AlertUser, AlertViaGovNotify, AlertViaLogging
 from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
 from secure_message.common.utilities import get_options, paginated_list_to_json, add_users_and_business_details
-from secure_message import constants
 from secure_message.constants import MESSAGE_LIST_ENDPOINT
 from secure_message.repository.modifier import Modifier
 from secure_message.repository.retriever import Retriever

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -217,7 +217,7 @@ class MessageModifyById(Resource):
     @staticmethod
     def _try_modify_unread(action, message, user):
         """Used to validate that the label can be modified to read"""
-        if message['msg_to'][0] != user.user_uuid:
+        if message['msg_to'][0] != user.user_uuid and message['msg_to'][0] != constants.NON_SPECIFIC_INTERNAL_USER:
             return False
         if action == 'add':
             return Modifier.add_unread(message, user)

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -1,22 +1,22 @@
+from datetime import datetime, timezone
 import unittest
 import uuid
-from werkzeug.exceptions import InternalServerError
 
-from datetime import datetime, timezone
 from flask import current_app, g
 from sqlalchemy import create_engine
+from werkzeug.exceptions import InternalServerError
 
+from secure_message import constants
 from secure_message.application import create_app
 from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
 from secure_message.repository import database
+from secure_message.repository.database import SecureMessage
 from secure_message.repository.modifier import Modifier
 from secure_message.repository.retriever import Retriever
 from secure_message.repository.saver import Saver
 from secure_message.validation.domain import DraftSchema
 from secure_message.validation.user import User
-from secure_message.repository.database import SecureMessage
-from secure_message import constants
 from tests.app import test_utilities
 
 

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -411,6 +411,95 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
                 with self.assertRaises(InternalServerError):
                     Modifier.replace_current_draft(2, draft)
 
+    def test_get_label_actor_to_respondent(self):
+        message_to_respondent = {'msg_id': 'test1',
+                                 'msg_to': ['0a7ad740-10d5-4ecb-b7ca-3c0384afb882'],
+                                 'msg_from': 'ce12b958-2a5f-44f4-a6da-861e59070a31',
+                                 'subject': 'MyMessage',
+                                 'body': 'hello',
+                                 'thread_id': '',
+                                 'collection_case': 'ACollectionCase',
+                                 'collection_exercise': 'ACollectionExercise',
+                                 'ru_id': 'f1a5e99c-8edf-489a-9c72-6cabe6c387fc',
+                                 'survey': test_utilities.BRES_SURVEY,
+                                 'from_internal': True}
+
+        self.assertEqual(Modifier._get_label_actor(user=self.user_internal, message=message_to_respondent),
+                         'ce12b958-2a5f-44f4-a6da-861e59070a31')
+        self.assertEqual(Modifier._get_label_actor(user=self.user_respondent, message=message_to_respondent),
+                         '0a7ad740-10d5-4ecb-b7ca-3c0384afb882')
+
+    def test_get_label_actor_to_bres_user(self):
+        user_bres = User(constants.BRES_USER, 'internal')
+        message_to_bres = {'msg_id': 'test2',
+                                     'msg_to': [constants.BRES_USER],
+                                     'msg_from': '0a7ad740-10d5-4ecb-b7ca-3c0384afb882',
+                                     'subject': 'MyMessage',
+                                     'body': 'hello',
+                                     'thread_id': '',
+                                     'collection_case': 'ACollectionCase',
+                                     'collection_exercise': 'ACollectionExercise',
+                                     'ru_id': 'f1a5e99c-8edf-489a-9c72-6cabe6c387fc',
+                                     'survey': test_utilities.BRES_SURVEY,
+                                     'from_internal': False}
+
+        self.assertEqual(Modifier._get_label_actor(user=user_bres, message=message_to_bres),
+                         constants.BRES_USER)
+        self.assertEqual(Modifier._get_label_actor(user=self.user_internal, message=message_to_bres),
+                         constants.BRES_USER)
+        self.assertEqual(Modifier._get_label_actor(user=self.user_respondent, message=message_to_bres),
+                         '0a7ad740-10d5-4ecb-b7ca-3c0384afb882')
+
+    def test_get_label_actor_to_group(self):
+        message_to_internal_group = {'msg_id': 'test3',
+                                     'msg_to': [constants.NON_SPECIFIC_INTERNAL_USER],
+                                     'msg_from': '0a7ad740-10d5-4ecb-b7ca-3c0384afb882',
+                                     'subject': 'MyMessage',
+                                     'body': 'hello',
+                                     'thread_id': '',
+                                     'collection_case': 'ACollectionCase',
+                                     'collection_exercise': 'ACollectionExercise',
+                                     'ru_id': 'f1a5e99c-8edf-489a-9c72-6cabe6c387fc',
+                                     'survey': test_utilities.BRES_SURVEY,
+                                     'from_internal': False}
+
+        self.assertEqual(Modifier._get_label_actor(user=self.user_internal, message=message_to_internal_group),
+                         constants.NON_SPECIFIC_INTERNAL_USER)
+        self.assertEqual(Modifier._get_label_actor(user=self.user_respondent, message=message_to_internal_group),
+                         '0a7ad740-10d5-4ecb-b7ca-3c0384afb882')
+
+    def test_get_label_actor_to_internal_user(self):
+        message_to_internal_user = {'msg_id': 'test4',
+                                    'msg_to': ['ce12b958-2a5f-44f4-a6da-861e59070a31'],
+                                    'msg_from': '0a7ad740-10d5-4ecb-b7ca-3c0384afb882',
+                                    'subject': 'MyMessage',
+                                    'body': 'hello',
+                                    'thread_id': '',
+                                    'collection_case': 'ACollectionCase',
+                                    'collection_exercise': 'ACollectionExercise',
+                                    'ru_id': 'f1a5e99c-8edf-489a-9c72-6cabe6c387fc',
+                                    'survey': test_utilities.BRES_SURVEY,
+                                    'from_internal': False}
+
+        self.assertEqual(Modifier._get_label_actor(user=self.user_internal, message=message_to_internal_user),
+                         'ce12b958-2a5f-44f4-a6da-861e59070a31')
+        self.assertEqual(Modifier._get_label_actor(user=self.user_respondent, message=message_to_internal_user),
+                         '0a7ad740-10d5-4ecb-b7ca-3c0384afb882')
+
+    def test_get_label_actor_raises_exception_for_missing_fields(self):
+        message_missing_fields = {'msg_id': 'test5',
+                                  'subject': 'MyMessage',
+                                  'body': 'hello',
+                                  'thread_id': '',
+                                  'collection_case': 'ACollectionCase',
+                                  'collection_exercise': 'ACollectionExercise',
+                                  'ru_id': 'f1a5e99c-8edf-489a-9c72-6cabe6c387fc',
+                                  'survey': test_utilities.BRES_SURVEY,
+                                  'from_internal': False}
+
+        with self.assertRaises(InternalServerError):
+            Modifier._get_label_actor(user=self.user_internal, message=message_missing_fields)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Fix for bug in modify labels endpoint**

The endpoint to modify labels on a message still had a hardcoded BRES constant, it could not cope with messages from or to specific internal users or the GROUP constant.
I have added logic to choose the appropriate actor so that the endpoint works.

**How to review:**

Currently these fixes are only needed for features on this branch of response-operations-ui:
[sm114/distinguish-unread-messages](https://github.com/ONSdigital/response-operations-ui/tree/sm114/distinguish-unread-messages)

**To replicate the bug:**
Run that response-operations branch and open an unread message from a respondent. The call to mark messages as read will not work, when you got back to the inbox it will still be highlighted unread as the call to update the label fails.

If you this branch of secure messaging it should function as expected where opening a message will mark it as read so returning to the inbox the opened message should no longer be highlighted.