### PR TITLE
Improve behave test output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,5 @@ lint:
 	pipenv check ./secure_message ./tests
 
 test: lint
-	pipenv run python run_tests.py
+	pipenv run behave --format progress
+	pipenv run pytest

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ lint:
 
 test: lint
 	pipenv run behave --format progress
-	pipenv run pytest
+	export APP_SETTINGS=TestConfig && pipenv run pytest && unset APP_SETTINGS

--- a/config.py
+++ b/config.py
@@ -30,9 +30,7 @@ class Config:
         SQLALCHEMY_DATABASE_URI = SECURE_MESSAGING_DATABASE_URL
 
     # LOGGING SETTINGS
-    SMS_LOG_LEVEL = os.getenv('SMS_LOG_LEVEL', 'INFO')
-    APP_LOG_LEVEL = os.getenv('APP_LOG_LEVEL', 'INFO')
-    SMS_WERKZEUG_LOG_LEVEL = os.getenv('SMS_WERKZEUG_LOG_LEVEL', 'INFO')
+    SMS_LOG_LEVEL = os.getenv('SMS_LOG_LEVEL', 'DEBUG')
 
     # EMAIL NOTIFICATION SETTINGS
     NOTIFICATION_SERVICE_ID = os.getenv('SERVICE_ID')
@@ -130,3 +128,6 @@ class TestConfig(DevConfig):
     SM_USER_AUTHENTICATION_PRIVATE_KEY = open("./jwt-test-keys/sm-user-authentication-encryption-private-key.pem").read()
     SM_USER_AUTHENTICATION_PUBLIC_KEY = open("./jwt-test-keys/sm-user-authentication-encryption-public-key.pem").read()
     USE_UAA = 0
+
+    # LOGGING SETTINGS
+    SMS_LOG_LEVEL = 'ERROR'

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,6 @@ applications:
     TESTING: False
     CSRF_ENABLED: True
     SMS_LOG_LEVEL: DEBUG
-    APP_LOG_LEVEL: DEBUG
     RAS_SM_PATH: /home/vcap/app
     DEV_PORT: 5050
   services:

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     os.environ['APP_SETTINGS'] = 'TestConfig'
 
     from behave import __main__ as behave_executable
-    behave_errors = behave_executable.main()
+    behave_errors = behave_executable.main(args="--format progress")
 
     test_dirs = os.listdir('./tests')
     suites_list = []
@@ -17,6 +17,6 @@ if __name__ == "__main__":
             test_path = f"./tests/{directory}"
             suite = loader.discover(test_path)
             suites_list.append(suite)
-            result = unittest.TextTestRunner(verbosity=2).run(suite)
+            result = unittest.TextTestRunner(verbosity=1).run(suite)
             if result.failures or result.errors or behave_errors:
                 sys.exit(1)

--- a/secure_message/application.py
+++ b/secure_message/application.py
@@ -28,7 +28,6 @@ from secure_message.resources.threads import ThreadById, ThreadList
 from secure_message.v2.resources.messages import MessageSendV2, MessageCounterV2
 
 
-logger_initial_config(service_name='ras-secure-message', log_level="DEBUG")
 logger = wrap_logger(logging.getLogger(__name__))
 
 
@@ -39,6 +38,8 @@ def create_app(config=None):
 
     missing_vars = [var for var in app.config['NON_DEFAULT_VARIABLES']
                     if app.config.get(var) is None]
+
+    logger_initial_config(service_name='ras-secure-message', log_level=app.config.get('SMS_LOG_LEVEL'))
 
     if missing_vars:
         raise MissingEnvironmentVariable(missing_vars)

--- a/secure_message/logger_config.py
+++ b/secure_message/logger_config.py
@@ -15,11 +15,11 @@ def logger_initial_config(service_name=None,
     if not logger_date_format:
         logger_date_format = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M%s")
     if not log_level:
-        log_level = os.getenv('SMS_LOG_LEVEL', 'INFO')
+        log_level = os.getenv('SMS_LOG_LEVEL', 'DEBUG')
     if not logger_format:
         logger_format = "%(message)s"
     if not service_name:
-        service_name = os.getenv('NAME', 'ras-frontstage')
+        service_name = os.getenv('NAME', 'ras-secure-message')
     try:
         indent = int(os.getenv('JSON_INDENT_LOGGING'))
     except TypeError:

--- a/secure_message/resources/health.py
+++ b/secure_message/resources/health.py
@@ -43,7 +43,6 @@ class HealthDetails(Resource):
         details = {'Name': current_app.config['NAME'],
                    'Version': current_app.config['VERSION'],
                    'SMS Log level': current_app.config['SMS_LOG_LEVEL'],
-                   'APP Log Level': current_app.config['APP_LOG_LEVEL'],
                    'API Functionality': func_list,
                    'Using party service mock': party.using_mock,
                    'SM JWT ENCRYPT': current_app.config['SM_JWT_ENCRYPT'],

--- a/tests/app/test_health_monitor.py
+++ b/tests/app/test_health_monitor.py
@@ -44,7 +44,6 @@ class HealthTestCase(unittest.TestCase):
         details = {'Name': '',
                    'Version': '',
                    'SMS Log level': '',
-                   'APP Log Level': '',
                    'API Functionality': '',
                    'Using party service mock': '',
                    'SM JWT ENCRYPT': '',

--- a/tests/behavioural/features/steps/run_behave_tests.py
+++ b/tests/behavioural/features/steps/run_behave_tests.py
@@ -1,8 +1,0 @@
-if __name__ == '__main__':
-    from behave import __main__ as behave_executable
-    behave_executable.main(None)
-
-    def before_scenario(context, scenario):
-        if "ignore" in scenario.effective_tags:
-            scenario.skip("Unimplemented Functionality")
-            return


### PR DESCRIPTION
**What is the context of this PR?**

The output from the behave tests was over powering everything and very difficult to see what's going on.
This PR changes the format of the tests which shows: 
* `.` for a pass
* `F` for a fail
* `S` for a skip

*Extras*
The run_behave_tests.py doesn't work in terminal, but works in pycharm.
run_lint.py fails with `file_stream` .. This can be solved by changing pylint_mccabe to pylint.extensions.mccabe in the .pylintrc file


**How to review**

To test, run the run_tests.py to see the output, and change a feature and unit test to fail to see the results.
Try running `make test` and check the output.
Suggest improvements