### PR TITLE
Split out utility method functionality and renamed it

### DIFF
--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -68,13 +68,11 @@ def add_string_query_args(string_query_args, arg, val):
 def process_paginated_list(paginated_list, host_url, user, message_args, endpoint=MESSAGE_LIST_ENDPOINT, body_summary=True):
     """used to change a pagination object to json format with links"""
     messages = []
-    msg_count = 0
     arg_joiner = ''
     if message_args.string_query_args != '?':
         arg_joiner = '&'
 
     for message in paginated_list.items:
-        msg_count += 1
         msg = message.serialize(user, body_summary=body_summary)
         msg['_links'] = {"self": {"href": f"{host_url}{MESSAGE_BY_ID_ENDPOINT}/{msg['msg_id']}"}}
         messages.append(msg)

--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -2,7 +2,6 @@ import collections
 import hashlib
 import logging
 
-from flask import jsonify
 from structlog import wrap_logger
 from secure_message.common.labels import Labels
 from secure_message.services.service_toggles import party, internal_user_service
@@ -66,7 +65,7 @@ def add_string_query_args(string_query_args, arg, val):
     return f'{string_query_args}&{arg}={val}'
 
 
-def paginated_list_to_json(paginated_list, host_url, user, message_args, endpoint=MESSAGE_LIST_ENDPOINT, body_summary=True):
+def process_paginated_list(paginated_list, host_url, user, message_args, endpoint=MESSAGE_LIST_ENDPOINT, body_summary=True):
     """used to change a pagination object to json format with links"""
     messages = []
     msg_count = 0
@@ -90,8 +89,7 @@ def paginated_list_to_json(paginated_list, host_url, user, message_args, endpoin
     if paginated_list.has_prev:
         links['prev'] = {
             "href": f"{host_url}{endpoint}{arg_joiner}{message_args.string_query_args}page={message_args.page - 1}&limit={message_args.limit}"}
-    messages = add_users_and_business_details(messages)
-    return jsonify({"messages": messages, "_links": links})
+    return messages, links
 
 
 def generate_etag(msg_to, msg_id, subject, body):

--- a/secure_message/resources/drafts.py
+++ b/secure_message/resources/drafts.py
@@ -10,7 +10,7 @@ from secure_message.authorization.authorizer import Authorizer
 from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
 from secure_message.constants import DRAFT_LIST_ENDPOINT
-from secure_message.common.utilities import get_options, paginated_list_to_json, generate_etag, add_users_and_business_details
+from secure_message.common.utilities import get_options, process_paginated_list, generate_etag, add_users_and_business_details
 from secure_message.repository.modifier import Modifier
 from secure_message.repository.retriever import Retriever
 from secure_message.repository.saver import Saver
@@ -92,9 +92,9 @@ class DraftList(Resource):
 
         result = Retriever().retrieve_message_list(g.user, message_args)
 
-        resp = paginated_list_to_json(result, request.host_url, g.user, message_args, DRAFT_LIST_ENDPOINT)
-        resp.status_code = 200
-        return resp
+        messages, links = process_paginated_list(result, request.host_url, g.user, message_args, DRAFT_LIST_ENDPOINT)
+        messages = add_users_and_business_details(messages)
+        return jsonify({"messages": messages, "_links": links})
 
 
 class DraftModifyById(Resource):

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -10,7 +10,7 @@ from secure_message.authorization.authorizer import Authorizer
 from secure_message.common.alerts import AlertUser, AlertViaGovNotify, AlertViaLogging
 from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
-from secure_message.common.utilities import get_options, paginated_list_to_json, add_users_and_business_details
+from secure_message.common.utilities import get_options, process_paginated_list, add_users_and_business_details
 from secure_message.constants import MESSAGE_LIST_ENDPOINT
 from secure_message.repository.modifier import Modifier
 from secure_message.repository.retriever import Retriever
@@ -36,7 +36,9 @@ class MessageList(Resource):
         message_service = Retriever()
         result = message_service.retrieve_message_list(g.user, message_args)
         logger.info("Successfully retrieved message list", user_uuid=g.user.user_uuid)
-        return make_response(paginated_list_to_json(result, request.host_url, g.user, message_args, MESSAGE_LIST_ENDPOINT), 200)
+        messages, links = process_paginated_list(result, request.host_url, g.user, message_args, MESSAGE_LIST_ENDPOINT)
+        messages = add_users_and_business_details(messages)
+        return jsonify({"messages": messages, "_links": links})
 
 
 class MessageSend(Resource):


### PR DESCRIPTION
**What is the context of this PR?**

paginated_list_to_json did too much and didn't describe what it was doing well enough (it does a lot more than taking a list and turning it into json).
Splitting this out will make the code slightly more readable, as it's a bit more obvious at a glance what is going on instead of it being hidden away by a function.  Also, it'll aid in the removal of the pagination in threads which we're going to do shortly.

**How to review**

Open a conversation and the messages should appear as expected
