### PR TITLE
Fix filtering by multiple survey

### DIFF
--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -4,23 +4,26 @@ import logging
 import urllib.parse
 
 from structlog import wrap_logger
+
 from secure_message.common.labels import Labels
-from secure_message.services.service_toggles import party, internal_user_service
 from secure_message.constants import MESSAGE_BY_ID_ENDPOINT, MESSAGE_LIST_ENDPOINT, MESSAGE_QUERY_LIMIT
+from secure_message.services.service_toggles import party, internal_user_service
 
 logger = wrap_logger(logging.getLogger(__name__))
-MessageArgs = collections.namedtuple('MessageArgs', 'page limit ru_id survey cc label desc ce')
+MessageArgs = collections.namedtuple('MessageArgs', 'page limit ru_id surveys cc label desc ce')
 
 
 def get_options(args, draft_only=False):
     """extract options from request , allow label to be set by caller"""
 
-    fields = {'page': 1, 'limit': MESSAGE_QUERY_LIMIT, 'ru_id': None, 'survey': None,
+    fields = {'page': 1, 'limit': MESSAGE_QUERY_LIMIT, 'ru_id': None, 'surveys': None,
               'desc': True, 'cc': None, 'label': None, 'ce': None}
 
-    for field in ['survey', 'cc', 'ce', 'ru_id', 'label']:
+    for field in ['cc', 'ce', 'ru_id', 'label']:
         if args.get(field):
             fields[field] = str(args.get(field))
+
+    fields['surveys'] = args.getlist('survey')
 
     for field in ['limit', 'page']:
         if args.get(field):
@@ -32,7 +35,7 @@ def get_options(args, draft_only=False):
         fields['label'] = Labels.DRAFT.value
 
     return MessageArgs(page=fields['page'], limit=fields['limit'], ru_id=fields['ru_id'],
-                       survey=fields['survey'], cc=fields['cc'], label=fields['label'],
+                       surveys=fields['surveys'], cc=fields['cc'], label=fields['label'],
                        desc=fields['desc'], ce=fields['ce'])
 
 

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -1,4 +1,5 @@
 import logging
+from pprint import pprint
 
 from flask import jsonify
 from sqlalchemy import and_, func, or_
@@ -40,8 +41,8 @@ class Retriever:
         if message_args.ru_id:
             conditions.append(SecureMessage.ru_id == str(message_args.ru_id))
 
-        if message_args.survey:
-            conditions.append(SecureMessage.survey == str(message_args.survey))
+        if message_args.surveys:
+            conditions.append(SecureMessage.survey.in_(message_args.surveys))
 
         if message_args.cc:
             conditions.append(SecureMessage.collection_case == message_args.cc)
@@ -96,8 +97,8 @@ class Retriever:
         if message_args.ru_id:
             conditions.append(SecureMessage.ru_id == str(message_args.ru_id))
 
-        if message_args.survey:
-            conditions.append(SecureMessage.survey == str(message_args.survey))
+        if message_args.surveys:
+            conditions.append(SecureMessage.survey.in_(message_args.surveys))
 
         if message_args.cc:
             conditions.append(SecureMessage.collection_case == str(message_args.cc))
@@ -166,8 +167,8 @@ class Retriever:
         if request_args.ru_id:
             conditions.append(SecureMessage.ru_id == request_args.ru_id)
 
-        if request_args.survey:
-            conditions.append(SecureMessage.survey == request_args.survey)
+        if request_args.surveys:
+            conditions.append(SecureMessage.survey.in_(request_args.surveys))
 
         if request_args.cc:
             conditions.append(SecureMessage.collection_case == request_args.cc)
@@ -203,13 +204,16 @@ class Retriever:
         """Retrieve a list of threads for an internal user"""
         conditions = []
 
+        pprint(request_args)
+
         logger.info("Retrieving list of threads for internal user", user_uuid=user.user_uuid)
 
         if request_args.ru_id:
             conditions.append(SecureMessage.ru_id == request_args.ru_id)
 
-        if request_args.survey:
-            conditions.append(SecureMessage.survey == request_args.survey)
+        if request_args.surveys:
+            conditions.append(SecureMessage.survey.in_(request_args.surveys))
+            pprint(request_args.surveys)
 
         if request_args.cc:
             conditions.append(SecureMessage.collection_case == request_args.cc)

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -1,5 +1,4 @@
 import logging
-from pprint import pprint
 
 from flask import jsonify
 from sqlalchemy import and_, func, or_
@@ -204,8 +203,6 @@ class Retriever:
         """Retrieve a list of threads for an internal user"""
         conditions = []
 
-        pprint(request_args)
-
         logger.info("Retrieving list of threads for internal user", user_uuid=user.user_uuid)
 
         if request_args.ru_id:
@@ -213,7 +210,6 @@ class Retriever:
 
         if request_args.surveys:
             conditions.append(SecureMessage.survey.in_(request_args.surveys))
-            pprint(request_args.surveys)
 
         if request_args.cc:
             conditions.append(SecureMessage.collection_case == request_args.cc)

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -1,5 +1,4 @@
 import logging
-from pprint import pprint
 
 from flask import g, jsonify, request
 from flask_restful import Resource
@@ -38,8 +37,6 @@ class ThreadList(Resource):
         """Get thread list"""
         logger.info("Getting list of threads for user", user_uuid=g.user.user_uuid)
         message_args = get_options(request.args)
-        pprint(request.args)
-
         result = Retriever().retrieve_thread_list(g.user, message_args)
 
         logger.info("Successfully retrieved threads for user", user_uuid=g.user.user_uuid)

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -1,8 +1,10 @@
 import logging
+from pprint import pprint
 
 from flask import g, jsonify, request
 from flask_restful import Resource
 from structlog import wrap_logger
+
 from secure_message.common.utilities import get_options, process_paginated_list, add_users_and_business_details
 from secure_message.constants import THREAD_LIST_ENDPOINT
 from secure_message.repository.retriever import Retriever
@@ -36,6 +38,7 @@ class ThreadList(Resource):
         """Get thread list"""
         logger.info("Getting list of threads for user", user_uuid=g.user.user_uuid)
         message_args = get_options(request.args)
+        pprint(request.args)
 
         result = Retriever().retrieve_thread_list(g.user, message_args)
 

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -256,7 +256,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         self.populate_database(5, add_draft=True)
         with self.app.app_context():
             with current_app.test_request_context():
-                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, survey=BRES_SURVEY)
+                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, surveys=[BRES_SURVEY])
                 result = Retriever().retrieve_message_list(self.user_internal, args)
                 msg = []
                 for message in result.items:
@@ -405,7 +405,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, survey=BRES_SURVEY, label='DRAFT')
+                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, surveys=[BRES_SURVEY], label='DRAFT')
                 response = Retriever().retrieve_message_list(self.user_internal, args)
                 msg = []
                 for message in response.items:
@@ -435,7 +435,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, survey=BRES_SURVEY, label='INBOX')
+                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, surveys=[BRES_SURVEY], label='INBOX')
                 response = Retriever().retrieve_message_list(self.user_internal, args)
                 msg = []
                 for message in response.items:
@@ -496,7 +496,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, survey=BRES_SURVEY)
+                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, surveys=[BRES_SURVEY])
                 response = Retriever().retrieve_message_list(self.user_respondent, args)
                 msg = []
                 for message in response.items:
@@ -511,7 +511,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, survey='AnotherSurvey')
+                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, surveys='AnotherSurvey')
                 response = Retriever().retrieve_message_list(self.user_respondent, args)
                 msg = []
                 for message in response.items:
@@ -626,7 +626,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, survey=BRES_SURVEY, desc=False)
+                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, surveys=[BRES_SURVEY], desc=False)
                 response = Retriever().retrieve_message_list(self.user_internal, args)
 
                 date = []
@@ -647,7 +647,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
         with self.app.app_context():
             with current_app.test_request_context():
-                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, survey=BRES_SURVEY, desc=True)
+                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT, surveys=[BRES_SURVEY], desc=True)
                 response = Retriever().retrieve_message_list(self.user_internal, args)
 
                 date = []

--- a/tests/app/test_utilities.py
+++ b/tests/app/test_utilities.py
@@ -5,5 +5,5 @@ BRES_SURVEY = "33333333-22222-3333-4444-88dc018a1a4c"
 
 
 def get_args(page=1, limit=100, survey="", cc="", ru="", label="", desc=True, ce=""):
-    return MessageArgs(page=page, limit=limit, ru_id=ru, survey=survey, cc=cc, label=label,
+    return MessageArgs(page=page, limit=limit, ru_id=ru, surveys=list(survey), cc=cc, label=label,
                        desc=desc, ce=ce)

--- a/tests/app/test_utilities.py
+++ b/tests/app/test_utilities.py
@@ -4,6 +4,6 @@ from secure_message.common.utilities import MessageArgs
 BRES_SURVEY = "33333333-22222-3333-4444-88dc018a1a4c"
 
 
-def get_args(page=1, limit=100, surveys=[], cc="", ru="", label="", desc=True, ce=""):
+def get_args(page=1, limit=100, surveys=None, cc="", ru="", label="", desc=True, ce=""):
     return MessageArgs(page=page, limit=limit, ru_id=ru, surveys=surveys, cc=cc, label=label,
                        desc=desc, ce=ce)

--- a/tests/app/test_utilities.py
+++ b/tests/app/test_utilities.py
@@ -4,6 +4,6 @@ from secure_message.common.utilities import MessageArgs
 BRES_SURVEY = "33333333-22222-3333-4444-88dc018a1a4c"
 
 
-def get_args(page=1, limit=100, survey="", cc="", ru="", label="", desc=True, ce=""):
-    return MessageArgs(page=page, limit=limit, ru_id=ru, surveys=list(survey), cc=cc, label=label,
+def get_args(page=1, limit=100, surveys=[], cc="", ru="", label="", desc=True, ce=""):
+    return MessageArgs(page=page, limit=limit, ru_id=ru, surveys=surveys, cc=cc, label=label,
                        desc=desc, ce=ce)

--- a/tests/behavioural/features/steps/endpoints.py
+++ b/tests/behavioural/features/steps/endpoints.py
@@ -1,6 +1,7 @@
+import copy
+
 from behave import given, when
 from flask import json
-import copy
 
 
 # These steps generate http requests and responses
@@ -283,6 +284,14 @@ def step_impl_the_threads_are_read(context):
 @given("the threads in survey '{survey}' are read")
 def step_impl_the_threads_in_specific_survey_are_returned(context, survey):
     url = context.bdd_helper.threads_get_url + f"?survey={survey}"
+    context.response = context.client.get(url, headers=context.bdd_helper.headers)
+    context.bdd_helper.store_messages_response_data(context.response.data)
+
+
+@when("the threads in are read with filters for both default and alternate surveys")
+def step_impl_the_threads_in_default_and_alternate_are_returned(context):
+    url = context.bdd_helper.threads_get_url + f"?survey={context.bdd_helper.default_survey}" \
+                                               f"&survey={context.bdd_helper.alternate_survey}"
     context.response = context.client.get(url, headers=context.bdd_helper.headers)
     context.bdd_helper.store_messages_response_data(context.response.data)
 

--- a/tests/behavioural/features/steps/secure_messaging_context_helper.py
+++ b/tests/behavioural/features/steps/secure_messaging_context_helper.py
@@ -165,6 +165,14 @@ class SecureMessagingContextHelper:
         return copy.deepcopy(SecureMessagingContextHelper.__ALTERNATIVE_RESPONDENT_USER_TOKEN)
 
     @property
+    def default_survey(self):
+        return copy.copy(SecureMessagingContextHelper.__DEFAULT_SURVEY)
+
+    @property
+    def alternate_survey(self):
+        return copy.copy(SecureMessagingContextHelper.__ALTERNATE_SURVEY)
+
+    @property
     def message_post_url(self):
         return self._message_post_url
 

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -500,3 +500,29 @@ Feature: Get threads list Endpoint V2
       Then a success status code (200) is returned
        And '1' messages are returned
        And all response messages have the label 'DRAFT'
+
+  Scenario: An internal user sends messages regarding multiple different surveys, validate that when the get the threads list
+            filtered by both surveys then all messages are returned
+    Given sending from internal specific user to respondent
+      And survey set to default survey
+      And the message is sent V2
+      And sending from internal specific user to respondent
+      And survey is set to alternate survey
+      And the message is sent V2
+      And the user is set as internal specific user
+    When the threads in are read with filters for both default and alternate surveys
+    Then  a success status code (200) is returned
+      And  '2' messages are returned
+
+  Scenario: A respondent sends messages regarding multiple different surveys, validate that when the get the threads list
+        filtered by both surveys then all messages are returned
+    Given sending from respondent to internal group
+      And survey set to default survey
+      And the message is sent V2
+      And sending from respondent to internal group
+      And survey is set to alternate survey
+      And the message is sent V2
+      And the user is set as internal specific user
+    When the threads in are read with filters for both default and alternate surveys
+    Then  a success status code (200) is returned
+      And  '2' messages are returned


### PR DESCRIPTION
**Fix a bug that was preventing multiple surveys in the filter**

Secure message was not properly handling filtering by multiple surveys

The condition for the filter in the database query was checking for equality so would not work as expected for lists of multiple surveys, now it checks for inclusion, and lists of surveys in the parameters are handled.

Dependent on this branch of ras-backstage:
[Ras Backstage: Fix multiple surveys secure message](https://github.com/ONSdigital/ras-backstage/pull/90)


**How to review**

Requires this branch of ras-backstage:
[Ras Backstage: Fix multiple surveys secure message](https://github.com/ONSdigital/ras-backstage/pull/90)

When running both this branch and the backstage fix branch, you should be able to filter by multiple survey ids in the parameters. Try posting messages to multiple different FDI surveys, the FDI option in the UI should now return all messages for any of the different FDI surveys. Also check all the other survey filters load as expected, they should be unaffected.
