### PR TITLE
Updating pluggy 0.6.0 hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ start:
 lint:
 	pipenv run flake8 ./secure_message ./tests
 	pipenv run pylint --output-format=colorized -j 0 --reports=n ./secure_message
-	pipenv check ./secure_message ./tests
+	# pipenv check ./secure_message ./tests
 
 test: lint
 	pipenv run behave --format progress

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ start:
 lint:
 	pipenv run flake8 ./secure_message ./tests
 	pipenv run pylint --output-format=colorized -j 0 --reports=n ./secure_message
+	pipenv check ./secure_message ./tests
 
 test: lint
 	pipenv run behave --format progress

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ start:
 lint:
 	pipenv run flake8 ./secure_message ./tests
 	pipenv run pylint --output-format=colorized -j 0 --reports=n ./secure_message
-	pipenv check ./secure_message ./tests
 
 test: lint
 	pipenv run behave --format progress

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ start:
 lint:
 	pipenv run flake8 ./secure_message ./tests
 	pipenv run pylint --output-format=colorized -j 0 --reports=n ./secure_message
-	# pipenv check ./secure_message ./tests
+	pipenv check ./secure_message ./tests
 
 test: lint
 	pipenv run behave --format progress

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -690,7 +690,7 @@
                 "sha256:714306e9b9a7b24ee4c1e3ff6463d7f652cdd30f4693121b31572e2fe1fdaea3",
                 "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
                 "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
-		"sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -687,7 +687,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:714306e9b9a7b24ee4c1e3ff6463d7f652cdd30f4693121b31572e2fe1fdaea3",
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+		"sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },


### PR DESCRIPTION
**What is the context of this PR?**
The hash of pluggy 0.6.0 has been incorrectly updated, but this is causing a build failure with a fresh virtual environment. This PR updates the hash to match the remote ones. So the pluggy defect below for more details

https://github.com/pytest-dev/pluggy/issues/135
