### PR TITLE
Add migration for event date columns on message table

### DIFF
--- a/migrations/001_create_event_dates_on_message.sql
+++ b/migrations/001_create_event_dates_on_message.sql
@@ -1,0 +1,3 @@
+ALTER TABLE securemessage.secure_message
+ADD COLUMN IF NOT EXISTS sent_at timestamp,
+ADD COLUMN IF NOT EXISTS read_at timestamp


### PR DESCRIPTION
**What is the context of this PR?**

Adds `sent_at` and `read_at` columns to the `secure_message` table in preparation for the code change that will populate these columns.

**How to review**

- Run the migration SQL against the secure message database, if running the ras-rm-docker-dev setup you can use `psql -h localhost -p 6432 -U postgres -d postgres -a -f migrations/001_create_event_dates_on_message.sql`
- Use the service and verify it works
- Run the acceptance tests