### PR TITLE
Fix pagination bug

### DIFF
--- a/secure_message/application.py
+++ b/secure_message/application.py
@@ -22,8 +22,8 @@ from secure_message.logger_config import logger_initial_config
 from secure_message.repository import database
 from secure_message.resources.health import DatabaseHealth, Health, HealthDetails
 from secure_message.resources.info import Info
-from secure_message.resources.messages import MessageCounter, MessageModifyById, MessageSend
-from secure_message.resources.threads import ThreadById, ThreadList
+from secure_message.resources.messages import MessageModifyById, MessageSend
+from secure_message.resources.threads import ThreadById, ThreadCounter, ThreadList
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -56,10 +56,10 @@ def create_app(config=None):
     api.add_resource(MessageSend, '/message/send', '/v2/messages')
     api.add_resource(MessageModifyById, '/message/<message_id>/modify',
                      '/v2/messages/modify/<message_id>')
-    api.add_resource(MessageCounter, '/v2/messages/count')
 
     api.add_resource(ThreadList, '/threads')
     api.add_resource(ThreadById, '/thread/<thread_id>', '/v2/threads/<thread_id>')
+    api.add_resource(ThreadCounter, '/v2/messages/count')
 
     app.oauth_client_token_expires_at = maya.now()
 

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -6,7 +6,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from structlog import wrap_logger
 from werkzeug.exceptions import InternalServerError, NotFound
 
-from secure_message import constants
 from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
 from secure_message.repository.database import db, Events, SecureMessage, Status
@@ -31,12 +30,20 @@ class Retriever:
         return result
 
     @staticmethod
-    def message_count_by_survey(user, survey, label=None):
-        """Count users messages for a specific survey"""
-        if user.is_internal:
-            status_conditions, survey_conditions = Retriever._get_conditions_internal_user(survey, user)
+    def thread_count_by_survey(user, survey, label=None):
+        """Count users threads for a specific survey"""
+
+        survey_conditions = []
+
+        if survey:
+            survey_conditions.append(SecureMessage.survey.in_(survey))
         else:
-            status_conditions, survey_conditions = Retriever._get_conditions_respondent(survey, user)
+            survey_conditions.append(True)
+
+        status_conditions = []
+
+        if not user.is_internal:
+            status_conditions = [Status.actor == str(user.user_uuid)]
 
         if label:
             try:
@@ -45,42 +52,19 @@ class Retriever:
                     filter(and_(*survey_conditions)). \
                     filter(Status.label == label).count()
             except Exception as e:
-                logger.error('Error retrieving count of unread messages from database', error=e)
-                raise InternalServerError(description="Error retrieving count of unread messages from database")
+                logger.error('Error retrieving count of unread threads from database', error=e)
+                raise InternalServerError(description="Error retrieving count of unread threads from database")
             return result
 
         try:
-            result = SecureMessage.query.join(Status).\
-                filter(or_(*status_conditions)).\
+            result = SecureMessage.query.join(Status). \
+                filter(or_(*status_conditions)). \
                 filter(and_(*survey_conditions)).\
                 distinct(SecureMessage.thread_id).count()
         except Exception as e:
-            logger.error('Error retrieving count of messages by survey from database', error=e)
-            raise InternalServerError(description="Error retrieving count of unread messages from database")
+            logger.error('Error retrieving count of threads by survey from database', error=e)
+            raise InternalServerError(description="Error retrieving count of unread threads from database")
         return result
-
-    @staticmethod
-    def _get_conditions_internal_user(survey, user):
-        """Sets the conditions/predicates that are used by the query for the case of an internal actor"""
-        status_conditions = [Status.actor == str(user.user_uuid), Status.actor == constants.NON_SPECIFIC_INTERNAL_USER]
-        survey_conditions = []
-        if survey:
-            survey_conditions.append(SecureMessage.survey.in_(survey))
-        else:
-            survey_conditions.append(True)
-        return status_conditions, survey_conditions
-
-    @staticmethod
-    def _get_conditions_respondent(survey, user):
-        """Sets the conditions/predicates that are used by the query for the case of an external actor"""
-        status_conditions = [Status.actor == str(user.user_uuid)]
-        survey_conditions = []
-        if survey:
-            survey_conditions.append(SecureMessage.survey.in_(survey))
-        else:
-            survey_conditions.append(True)
-
-        return status_conditions, survey_conditions
 
     @staticmethod
     def retrieve_thread_list(user, request_args):

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -185,19 +185,3 @@ class MessageModifyById(Resource):
             raise BadRequest(description=f"Invalid action requested: {action}")
 
         return action, label
-
-
-class MessageCounter(Resource):
-    """Get count of unread messages using v2 endpoint"""
-    @staticmethod
-    def get():
-        survey = request.args.getlist('survey')
-        if request.args.get('label'):
-            label = str(request.args.get('label'))
-            if label.lower() == 'unread':
-                return jsonify(name=label, total=Retriever().message_count_by_survey(g.user, survey, label))
-            else:
-                logger.debug('Invalid label name', name=label, request=request.url)
-                raise BadRequest(description="Invalid label")
-        else:
-            return jsonify(total=Retriever().message_count_by_survey(g.user, survey))

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -1,9 +1,9 @@
 import logging
 
 from flask import g, jsonify, request
+from werkzeug.exceptions import BadRequest
 from flask_restful import Resource
 from structlog import wrap_logger
-from werkzeug.exceptions import BadRequest
 
 from secure_message.common.utilities import get_options, process_paginated_list, add_users_and_business_details
 from secure_message.constants import THREAD_LIST_ENDPOINT

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -3,6 +3,7 @@ import logging
 from flask import g, jsonify, request
 from flask_restful import Resource
 from structlog import wrap_logger
+from werkzeug.exceptions import BadRequest
 
 from secure_message.common.utilities import get_options, process_paginated_list, add_users_and_business_details
 from secure_message.constants import THREAD_LIST_ENDPOINT
@@ -43,3 +44,19 @@ class ThreadList(Resource):
         messages, links = process_paginated_list(result, request.host_url, g.user, message_args, THREAD_LIST_ENDPOINT)
         messages = add_users_and_business_details(messages)
         return jsonify({"messages": messages, "_links": links})
+
+
+class ThreadCounter(Resource):
+    """Get count of unread messages using v2 endpoint"""
+    @staticmethod
+    def get():
+        survey = request.args.getlist('survey')
+        if request.args.get('label'):
+            label = str(request.args.get('label'))
+            if label.lower() == 'unread':
+                return jsonify(name=label, total=Retriever().thread_count_by_survey(g.user, survey, label))
+            else:
+                logger.debug('Invalid label name', name=label, request=request.url)
+                raise BadRequest(description="Invalid label")
+        else:
+            return jsonify(total=Retriever().thread_count_by_survey(g.user, survey))

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -20,6 +20,7 @@ from tests.app.test_utilities import BRES_SURVEY, get_args
 class RetrieverTestCaseHelper:
 
     default_internal_actor = 'internal_actor'
+    second_internal_actor = 'second_internal_actor'
     default_external_actor = 'external_actor'
 
     """Helper class for Retriever Tests"""
@@ -171,6 +172,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
             self.db = database.db
 
         self.user_internal = User(RetrieverTestCaseHelper.default_internal_actor, 'internal')
+        self.second_user_internal = User(RetrieverTestCaseHelper.second_internal_actor, 'internal2')
         self.user_respondent = User(RetrieverTestCaseHelper.default_external_actor, 'respondent')
         party.use_mock_service()
         self.app.config['NOTIFY_CASE_SERVICE'] = '1'
@@ -395,6 +397,16 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
                     thread = Retriever().retrieve_thread(thread_ids[x], self.user_internal)
                     self.assertEqual(date[x], str(thread.all()[0].events[0].date_time))
                     self.assertEqual(msg_ids[x], thread.all()[0].events[0].msg_id)
+
+    def test_thread_count_by_survey(self):
+        """checks that the returned thread count is the same for every internal user"""
+        self.create_threads(5)
+
+        with self.app.app_context():
+            with current_app.test_request_context():
+                thread_count_internal = Retriever().thread_count_by_survey(self.user_internal, BRES_SURVEY)
+                thread_count_second_internal = Retriever().thread_count_by_survey(self.second_user_internal, BRES_SURVEY)
+                self.assertEqual(thread_count_internal, thread_count_second_internal)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What is the context of this PR?**

https://trello.com/c/q17Lr227/208-fix-pagination-in-secure-messaging

A bug existed in secure message where not all pagination links were showing.  When retrieving the counts of messages by survey, the SQL was retrieving a count of any conversations logged against the current user (their uuid) or GROUP.  If  different user logged in then the count wasn't retrieving all conversations.  
&nbsp;  
&nbsp;  
**How to review**

To recreate the issue:

- Bring everything up in Docker
- Run the acceptance tests to set up conversations
- Log in as uaa_user and create a few more conversations to push the pagination to the 5th page
- Log in as a different internal user (see below for instructions)
- Navigate to messages - only the first 2 pages are displayed, although you can change the page number in the URL to navigate to the 4th and 5th pages.

- Run this branch locally and navigate to messages (both as uaa_user and a different user).  The same number of messages should be displayed for each.
- Acceptance tests should still all pass

&nbsp;  
&nbsp;  

**To create a new internal user through UAA**

- Retrieve a bearer token:

`curl 'http://localhost:9080/oauth/token' -i -u 'admin:admin_secret' -X POST -H 'Content-Type: application/x-www-form-urlencoded' -H 'Accept: application/json' -d 'grant_type=client_credentials&response_type=token&token_format=opaque'`

- Create a new user, replacing the bearer token with the one you've retrieved and adding in your details (username, name, password etc.):

`curl 'http://localhost:9080/Users' -i -X POST -H 'Accept: application/json' -H 'Authorization: Bearer 34224c536b3648bd8d166acc5be4159f' -H 'Content-Type: application/json'  -d '{
"userName" : "your_username",
"name" : {
"formatted" : "given name family name",
"familyName" : "Surname",
"givenName" : "First_name"
},
"emails": [{
"value": "email@email.com",
"primary": true
}],
"active": true,
"verified": true,
"password": "password"
}’`



