### PR TITLE
Add conversation record for every conversation

### DIFF
--- a/add-convo-record-for-every-convo.py
+++ b/add-convo-record-for-every-convo.py
@@ -1,0 +1,24 @@
+from sqlite3 import DatabaseError
+import sys
+
+from sqlalchemy import create_engine, insert
+from sqlalchemy.orm import sessionmaker
+
+from config import Config
+from secure_message.repository.database import Conversation, SecureMessage
+
+engine = create_engine(Config.SQLALCHEMY_DATABASE_URI)
+Session = sessionmaker(bind=engine)
+db = Session()
+
+try:
+    subquery = db.query(Conversation.id)
+    distinct_ids = db.query(SecureMessage.thread_id).filter(~SecureMessage.thread_id.in_(subquery)).distinct()
+    for thread_id in distinct_ids:
+        db.execute(insert(Conversation).values({'id': thread_id, 'is_closed': 'False'}))
+        print('Added thread_id: {}'.format(thread_id[0]))
+    db.commit()
+except DatabaseError:
+    db.rollback()
+    print(DatabaseError)
+    sys.exit('Exiting')


### PR DESCRIPTION
### What is the context of this PR?

This is the next step in the db migration and is needed to put the data to a consistent state and to allow for the following PR's to be mergeable:

https://github.com/ONSdigital/ras-secure-message/pull/212

https://github.com/ONSdigital/ras-frontstage/pull/352

Trello card: https://trello.com/c/wC4PUlNr/12-add-conversation-record-for-every-conversation-3

### How to review

Does it work? 

- Try removing an` id` from your `conversation` table and its corresponding key from the `secure_message `table 
- Check that when you run the script 
i.e. `python add-convo-record-for-every-convo.py` that it is added. 

- You can do a print statement to check the actual SQL that is ran and check what gets inserted into the `conversation` table.
