### PR TITLE
Fixes access to messages for respondents

### DIFF
--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -85,6 +85,8 @@ class Retriever:
             t = db.session.query(SecureMessage.thread_id, func.max(SecureMessage.id)  # pylint:disable=no-member
                                  .label('max_id')) \
                 .join(Conversation) \
+                .join(Status) \
+                .filter(Status.actor == user.user_uuid) \
                 .filter(Conversation.is_closed.is_(request_args.is_closed)) \
                 .group_by(SecureMessage.thread_id).subquery('t')
 
@@ -158,16 +160,18 @@ class Retriever:
     def retrieve_thread(thread_id, user):
         if user.is_respondent:
             logger.info("Retrieving messages in thread for respondent", thread_id=thread_id, user_uuid=user.user_uuid)
-            return Retriever._retrieve_thread_for_respondent(thread_id)
+            return Retriever._retrieve_thread_for_respondent(thread_id, user)
         logger.info("Retrieving messages in thread for internal user", thread_id=thread_id, user_uuid=user.user_uuid)
         return Retriever._retrieve_thread_for_internal_user(thread_id)
 
     @staticmethod
-    def _retrieve_thread_for_respondent(thread_id):
+    def _retrieve_thread_for_respondent(thread_id, user):
         """returns list of messages for thread id for a respondent"""
         try:
             result = SecureMessage.query.join(Conversation) \
+                .join(Status) \
                 .filter(SecureMessage.thread_id == thread_id) \
+                .filter(Status.actor == user.user_uuid) \
                 .order_by(SecureMessage.id.desc())
 
             if not result.all():


### PR DESCRIPTION
# Motivation and Context
Ensures users only sees conversations relevant to them

# What has changed
Uses status table to determine who should see a conversation

# How to test?
- Sign in to response ops 
- Send a message to respondent@example.com
- Send another message to example@example.com
- Sign in to frontstage as respondent@example.com
- Verify the message for example@example.com is not visible
- Sign in to frontstage as example@example.com
- Verify the message for respondent@example.com is not visible
