### PR TITLE
Fix incorrect call to get user details

### DIFF
--- a/secure_message/validation/user.py
+++ b/secure_message/validation/user.py
@@ -22,4 +22,4 @@ class User:
 
     @staticmethod
     def is_valid_respondent(uuid):
-        return party.get_users_details(uuid) is not None
+        return party.get_user_details(uuid) is not None


### PR DESCRIPTION
**What is the context of this PR?**
The validator in secure messaging is currently sending to the wrong function, it should be get_user_details, instead it is calling to get_users_details which then separates the uuid into its parts and throws an exception. This PR is only to stop the noise the exception is causing and fix the immediate issue as it is in prod, the fact that the exception wasn't being handled and saying the message was valid when it was not will be raised in another card. 

**How to review**
Send a message internally and check the logs aren't throwing a exception
