### PR TITLE
Fix bug to call Notify when a new message is sent from internal to ex…

### DIFF
--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -86,8 +86,8 @@ class MessageSend(Resource):
         if g.user.is_internal:
             party_data = party.get_user_details(message.msg_to[0])  # NOQA TODO avoid 2 lookups (see validate)
             if party_data:
-                if 'emailAddress' in party_data and party_data['emailAddress'].strip():
-                    recipient_email = party_data['emailAddress'].strip()
+                if 'emailAddress' in party_data[0] and party_data[0]['emailAddress'].strip():
+                    recipient_email = party_data[0]['emailAddress'].strip()
                     alert_method = AlertViaLogging() if current_app.config['NOTIFY_VIA_GOV_NOTIFY'] == '0' else AlertViaGovNotify()
                     alert_user = AlertUser(alert_method)
                     alert_user.send(recipient_email, message.msg_id)

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -262,7 +262,7 @@ class FlaskTestCase(unittest.TestCase):
                                                                        "status": "ACTIVE",
                                                                        "sampleUnitType": "BI"}, 200))
     @patch.object(AlertViaLogging, 'send')
-    def test_notify_called(self, mock_alerter, mock_party):
+    def test_notify_called(self, mock_alerter, _):
         """Test that Notify is called when sending a new secure message """
 
         url = "http://localhost:5050/message/send"

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -254,6 +254,21 @@ class FlaskTestCase(unittest.TestCase):
         self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)
         self.assertTrue(case.called)
 
+    @patch.object(PartyServiceMock, 'get_user_details', return_value=({"id": "f62dfda8-73b0-4e0e-97cf-1b06327a6712",
+                                                                       "firstName": "Bhavana",
+                                                                       "emailAddress": "example@example.com",
+                                                                       "lastName": "Lincoln",
+                                                                       "telephone": "+443069990888",
+                                                                       "status": "ACTIVE",
+                                                                       "sampleUnitType": "BI"}, 200))
+    @patch.object(AlertViaLogging, 'send')
+    def test_notify_called(self, mock_alerter, mock_party):
+        """Test that Notify is called when sending a new secure message """
+
+        url = "http://localhost:5050/message/send"
+        self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)
+        self.assertTrue(mock_alerter.called)
+
     @patch.object(message_logger, 'error')
     @patch.object(MessageSend, '_try_send_alert_email', side_effect=Exception('SomethingBad'))
     def test_exception_in_alert_listeners_raises_exception_but_returns_201(self, mock_sender, mock_logger):


### PR DESCRIPTION
**What is the context of this PR?**

We currently are not notifying respondents that they have received a secure message by email. The message is still being sent and received as expected, its the notification by email which is failing. The error in the logs is "User does not have an emailAddress specified" and was logged for every secure 

https://trello.com/c/p0IJOD4P

**What's changed**

An 'if' statement in the code the code was silently failing so the app thought that there was no email address for the respondent, even though there was one.  

**How to review**

All tests should still pass.
Send a secure message from internal to external and check that Notify gets called (this can only be done from preprod).