### PR TITLE
Index list to enable case events being generated by secure message

### DIFF
--- a/secure_message/authentication/jwt.py
+++ b/secure_message/authentication/jwt.py
@@ -12,7 +12,7 @@ def encode(data):
     """
     jwt_algorithm = current_app.config['SM_JWT_ALGORITHM']
     jwt_secret = current_app.config['JWT_SECRET']
-    return jwt.encode(data, jwt_secret, algorithm=jwt_algorithm, headers={"alg": jwt_algorithm, 'typ': 'jwt'})
+    return jwt.encode(data, jwt_secret, algorithm=jwt_algorithm, headers={"alg": jwt_algorithm, 'typ': 'jwt'})  # NOQA pylint:disable-all
 
 
 def decode(token):

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -109,11 +109,13 @@ class MessageSend(Resource):
     def _get_user_name(user, message):
 
         user_name = 'Unknown user'
-        user_data = internal_user_service.get_user_details(message.msg_from) if user.is_internal else party.get_user_details(message.msg_from)
+        is_internal_user = user.is_internal
+        user_data = internal_user_service.get_user_details(message.msg_from) if is_internal_user else party.\
+            get_user_details(message.msg_from)
 
         if user_data:
-            first_name = user_data.get('firstName', '')
-            last_name = user_data.get('lastName', '')
+            first_name = user_data.get('firstName', '') if is_internal_user else user_data[0].get('firstName', '')
+            last_name = user_data.get('lastName', '') if is_internal_user else user_data[0].get('lastName', '')
             full_name = f'{first_name} {last_name}'.strip()
             if full_name:
                 user_name = full_name

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -236,7 +236,7 @@ class FlaskTestCase(unittest.TestCase):
                 self.assertTrue(row is not None)
 
     @patch.object(case_service, 'store_case_event')
-    def test_case_service_not_called_on_sent_if_NotifyCaseService_is_not_set(self, case):
+    def test_case_service_not_called_on_sent_if_notify_case_service_is_not_set(self, case):
         """Test case service not called if not set to do so in config"""
 
         self.app.config['NOTIFY_CASE_SERVICE'] = '0'
@@ -245,7 +245,7 @@ class FlaskTestCase(unittest.TestCase):
         self.assertFalse(case.called)
 
     @patch.object(case_service, 'store_case_event')
-    def test_case_service_called_on_sent_if_NotifyCaseService_is_set(self, case):
+    def test_case_service_called_on_sent_if_notify_case_service_is_set(self, case):
         """Test case service called if set to do so in config """
 
         self.app.config["NOTIFY_VIA_GOV_NOTIFY"] = '0'
@@ -332,12 +332,12 @@ class FlaskTestCase(unittest.TestCase):
         self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)
         self.assertFalse(mock_alerter.called)
 
-    @patch.object(PartyServiceMock, 'get_user_details', return_value=({"id": "f62dfda8-73b0-4e0e-97cf-1b06327a6712",
-                                                                       "emailAddress": "   ",
-                                                                       "lastName": "",
-                                                                       "telephone": "+443069990888",
-                                                                       "status": "ACTIVE",
-                                                                       "sampleUnitType": "BI"}))
+    @patch.object(PartyServiceMock, 'get_user_details', return_value=([{"id": "f62dfda8-73b0-4e0e-97cf-1b06327a6712",
+                                                                        "emailAddress": "   ",
+                                                                        "lastName": "",
+                                                                        "telephone": "+443069990888",
+                                                                        "status": "ACTIVE",
+                                                                        "sampleUnitType": "BI"}]))
     @patch.object(CaseServiceMock, 'store_case_event')
     def test_if_respondent_has_no_first_name_or_last_name_then_unknown_user_passed_to_case_service(self, mock_case, mock_party):
         """Test if party data has no name for the user then a constant of 'Unknown user' is used"""
@@ -361,7 +361,8 @@ class FlaskTestCase(unittest.TestCase):
         self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)
         mock_case.assert_called()
 
-    @patch.object(InternalUserServiceMock, 'get_user_details', return_value=({"id": "f62dfda8-73b0-4e0e-97cf-1b06327a6712",
+    @patch.object(InternalUserServiceMock, 'get_user_details', return_value=({"id": "f62dfda8-73b0-4e0e-97cf-"
+                                                                                    "1b06327a6712",
                                                                               "emailAddress": "   ",
                                                                               "lastName": "",
                                                                               "telephone": "+443069990888"}))

--- a/tests/app/test_saver.py
+++ b/tests/app/test_saver.py
@@ -117,7 +117,7 @@ class SaverTestCase(unittest.TestCase):
                 with self.assertRaises(MessageSaveException):
                     Saver().save_msg_event(message_event['msg_id'], message_event['event'], mock_session)
 
-    def test_status_commit_exception_raises_MessageSaveException(self):
+    def test_status_commit_exception_raises_message_save_exception(self):
         """check status commit exception clears the session"""
         message_status = {'msg_id': 'AMsgId', 'actor': 'Tej'}
         with self.app.app_context():
@@ -125,7 +125,7 @@ class SaverTestCase(unittest.TestCase):
                 with self.assertRaises(MessageSaveException):
                     Saver().save_msg_status(message_status['actor'], message_status['msg_id'], 'INBOX, UNREAD')
 
-    def test_event_commit_exception_raises_MessageSaveException(self):
+    def test_event_commit_exception_raises_message_save_exception(self):
         """check event commit exception clears the session"""
         message_event = {'msg_id': 'AMsgId', 'event': EventsApi.SENT.value, 'date_time': ''}
         with self.app.app_context():

--- a/tests/integration/test_case_service_integration.py
+++ b/tests/integration/test_case_service_integration.py
@@ -36,7 +36,7 @@ class CaseServiceIntegrationTestCase(unittest.TestCase):
         self.assertEqual(status_code, 201)
 
     @unittest.SkipTest
-    def test_createdBy_under_limit(self):
+    def test_created_by_under_limit(self):
         """Post data to case_service"""
         sut = case_service
         sut.use_real_service()
@@ -46,7 +46,7 @@ class CaseServiceIntegrationTestCase(unittest.TestCase):
         self.assertEqual(status_code, 201)
 
     @unittest.SkipTest
-    def test_createdBy_over_limit(self):
+    def test_created_by_over_limit(self):
         """Post data to case_service"""
         sut = case_service
         sut.use_real_service()
@@ -56,7 +56,7 @@ class CaseServiceIntegrationTestCase(unittest.TestCase):
         self.assertEqual(status_code, 400)
 
     @unittest.SkipTest
-    def test_createdBy_is_empty(self):
+    def test_created_by_is_empty(self):
         """Post data to case_service"""
         sut = case_service
         sut.use_real_service()
@@ -66,7 +66,7 @@ class CaseServiceIntegrationTestCase(unittest.TestCase):
         self.assertEqual(status_code, 400)
 
     @unittest.SkipTest
-    def test_createdBy_is_None(self):
+    def test_created_by_is_none(self):
         """Post data to case_service"""
         sut = case_service
         sut.use_real_service()


### PR DESCRIPTION
**What is the context of this PR?**
Case events weren't being generated by secure message as key errors were being hit fromuser_data

**How to review**

send a message from frontstage to rops, search for `AttributeError` in logs, should not see one