### PR TITLE
Stopped generating errors on empty thread list

### DIFF
--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -148,6 +148,9 @@ def add_business_details(messages):
 
 def add_users_and_business_details(messages):
     """Add both user and business details to messages based on data from party service"""
+    if not messages:
+        return messages
+
     messages = add_to_details(messages)
     messages = add_from_details(messages)
     logger.info("Successfully added to and from details")


### PR DESCRIPTION
**What is the context of this PR?**
When a user requests an empty thread list on fronstage or R-Ops, a exception is generated on secure-message and party-service saying parameter id is required. This PR fixes it by checking if theres an empty list before making any calls to the party service and stops the generation of the exceptions. 

Link to Trello card
https://trello.com/c/C4Pd8KFG/225-bug-errors-generated-when-viewing-an-empty-list-in-secure-message-the-parameter-id-is-required-s

**How to review**
Run the tests/acceptance tests and when checking a thread list with no messages, no exception should be generated on secure-message and party-service

