### PR TITLE
Changed log line to key value pair for RasNotifyException

### DIFF
--- a/secure_message/exception/exceptions.py
+++ b/secure_message/exception/exceptions.py
@@ -16,7 +16,7 @@ class MessageSaveException(HTTPException):
 
     def __init__(self, message, survey_id=None, party_id=None, status_code=None):
         HTTPException.__init__(self)
-        self.description = message, survey_id, party_id
+        self.description = {'message': message, 'survey_id': survey_id, 'party_id': party_id}
         if status_code is not None:
             self.code = status_code
 

--- a/tests/app/test_exceptions.py
+++ b/tests/app/test_exceptions.py
@@ -7,11 +7,12 @@ class ExceptionsTestCase(unittest.TestCase):
     """Test case for checking custom exceptions"""
     def test_defaults_in_message_save_exception(self):
         save_exception = MessageSaveException("Test", None, None)
-        self.assertEqual(save_exception.description, ("Test", None, None))
+        self.assertEqual(save_exception.description, {'message': 'Test', 'survey_id': None, 'party_id': None})
         self.assertEqual(save_exception.code, 500)
 
     def test_defaults_in_notify_exception(self):
         notify_exception = RasNotifyException()
         self.assertEqual(notify_exception.code, 500)
-        self.assertEqual(notify_exception.description, ('There was a problem sending a notification via RM Notify-Gateway to GOV.UK Notify',
-                                                        None, None))
+        self.assertEqual(notify_exception.description, {'message': 'There was a problem sending a notification via RM '
+                                                                   'Notify-Gateway to GOV.UK Notify',
+                                                        'survey_id': None, 'party_id': None})


### PR DESCRIPTION
## What is the context of this PR?

Logging out data for a ras-notify error comes out in a wrong format by only printing out the values. This PR turns the description of the error into a key/value pair instead of only the value.

## How to review

- Stop notifygateway and send a message from internal to external. Secure Message should log out RasNotifyException in a key/value pair
- Run acceptance tests and unit tests
