### PR TITLE
marked redundant /labels endpoint in documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -268,6 +268,8 @@ Note there is only an UNREAD label , absence of `UNREAD` is interpreted as the m
 
 This gives a count of messages that have not been read for a specific user. There are no current requirements around internal users.
 
+NOTE: This endpoint does not appear to be used anywhere, and is redundant.
+
 #### Example JSON Response
 
 ```json


### PR DESCRIPTION
**What is the context of this PR?**

For this PR I have been looking at the redundant API endpoints for secure message.

[Trello Card](https://trello.com/c/ODTURAH3)

Describe what you have changed and why, link to other PRs or Issues as appropriate.

Added a note to the API.md file to identify the "/labels" endpoint as unused in the code.

**How to review**

Check API.md is correct.