### PR TITLE
Validates user claim on message post by calling out to party

### DIFF
--- a/API.md
+++ b/API.md
@@ -52,7 +52,7 @@ See the endpoint descriptions for detailed usage of each field. This is an overv
 * Survey . (survey). This is the uuid of the survey . It is mandatory when saving a message.
 * Collection Exercise .  (collection exercise) uuid of the collection exercise , can be used as a filter option (ce)
 * Reporting unit . (ru) uuid of the reporting unit . Can be used as a filter option.
-* Labels . These can be used to set a status on a message , or retrieve messages with a specific label. Valid labels:
+* Labels . These can be used to set a status on a message, or retrieve messages with a specific label. Valid labels:
     * SENT  Added to a message for the actor who sent the message
     * INBOX Added to the message for the actor who received the message
     * UNREAD Added to a message to indicate that a message has not been read

--- a/secure_message/api_mocks/party_service_mock.py
+++ b/secure_message/api_mocks/party_service_mock.py
@@ -1,7 +1,6 @@
 import logging
 from structlog import wrap_logger
 
-
 logger = wrap_logger(logging.getLogger(__name__))
 
 
@@ -24,6 +23,21 @@ class PartyServiceMock:
             logger.error(f'Party service failed for uuid:{uuids}')
             user_details = None
         return user_details
+
+    def does_user_have_claim(self, user_id, bus_id, survey_id):
+        user_details = self._respondent_ids[user_id]
+        associations = user_details['associations']
+        is_enrolled = self._is_user_enrolled_on_survey(associations, bus_id, survey_id)
+        return user_details['status'] == 'ACTIVE' and is_enrolled
+
+    @staticmethod
+    def _is_user_enrolled_on_survey(associations, bus_id, survey_id):
+        for association in associations:
+            surveys = [v['surveyId'] for v in association['enrolments'] if v['enrolmentStatus'] == 'ENABLED']
+            if survey_id in surveys and association['partyId'] == bus_id:
+                return True
+
+        return False
 
     _business_details = {'c614e64e-d981-4eba-b016-d9822f09a4fb': {"id": "c614e64e-d981-4eba-b016-d9822f09a4fb",
                                                                   "name": "AOL"},
@@ -71,81 +85,276 @@ class PartyServiceMock:
                                                                   "id": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
                                                                   "sampleUnitRef": "50012345678",
                                                                   "sampleUnitType": "B"}}
-    _respondent_ids = {'f62dfda8-73b0-4e0e-97cf-1b06327a6712': {"id": "f62dfda8-73b0-4e0e-97cf-1b06327a6712",
-                                                                "firstName": "Bhavana",
-                                                                "lastName": "Lincoln",
-                                                                "emailAddress": "lincoln.bhavana@gmail.com",
-                                                                "telephone": "+443069990888",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"},
-                       'ce12b958-2a5f-44f4-a6da-861e59070a31': {"id": "ce12b958-2a5f-44f4-a6da-861e59070a31",
-                                                                "firstName": "Lars",
-                                                                "lastName": "McEachern",
-                                                                "emailAddress": "mclars@yahoo.com",
-                                                                "telephone": "+443069990413",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"},
-                       '0a7ad740-10d5-4ecb-b7ca-3c0384afb882': {"id": "0a7ad740-10d5-4ecb-b7ca-3c0384afb882",
-                                                                "firstName": "Vana",
-                                                                "lastName": "Oorschot",
-                                                                "emailAddress": "vana123@aol.com",
-                                                                "telephone": "+443069990289",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"},
-                       '01b51fcc-ed43-4cdb-ad1c-450f9986859b': {"id": "01b51fcc-ed43-4cdb-ad1c-450f9986859b",
-                                                                "firstName": "Chandana",
-                                                                "lastName": "Blanchet",
-                                                                "emailAddress": "cblanc@hotmail.co.uk",
-                                                                "telephone": "+443069990854",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"},
-                       'dd5a38ff-1ecb-4634-94c8-2358df33e614': {"id": "dd5a38ff-1ecb-4634-94c8-2358df33e614",
-                                                                "firstName": "Ida",
-                                                                "lastName": "Larue",
-                                                                "emailAddress": "ilarue47@yopmail.com",
-                                                                "telephone": "+443069990250",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"},
-                       'AnotherSurvey': {"id": "AnotherSurvey",
-                                         "firstName": "AnotherSurvey",
-                                         "lastName": "",
-                                         "emailAddress": "",
-                                         "telephone": "",
-                                         "status": "",
-                                         "sampleUnitType": "BI"},
-                       'ce12b958-2a5f-44f4-a6da-861e59070a32': {"id": "ce12b958-2a5f-44f4-a6da-861e59070a32",
-                                                                "firstName": "Liz",
-                                                                "lastName": "Larkin",
-                                                                "emailAddress": "ilarue47@yopmail.com",
-                                                                "telephone": "+443069990250",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"},
-                       'db036fd7-ce17-40c2-a8fc-932e7c228397': {"id": "db036fd7-ce17-40c2-a8fc-932e7c228397",
-                                                                "firstName": "Peter",
-                                                                "lastName": "Smith",
-                                                                "emailAddress": "peter.smith@hostmail.com",
-                                                                "telephone": "+447894056785",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"},
-                       'ab123456-ce17-40c2-a8fc-abcdef123456': {"associations": [{"enrolments":
-                                                                                  [{"enrolmentStatus": "ENABLED",
-                                                                                    "name": "Business Register and Employment Survey",
-                                                                                    "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"}],
-                                                                                  "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
-                                                                                  "sampleUnitRef": "50012345678"}],
-                                                                "id": "ab123456-ce17-40c2-a8fc-abcdef123456",
-                                                                "firstName": "Ivor",
-                                                                "lastName": "Bres",
-                                                                "emailAddress": "ivor.bres@hostmail.com",
-                                                                "telephone": "+447894056785",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"},
-                       '654321ab-ce17-40c2-a8fc-abcdef123456': {"associations": [{"enrolments": [], "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
-                                                                                  "sampleUnitRef": "50012345678"}],
-                                                                "id": "654321ab-ce17-40c2-a8fc-abcdef123456",
-                                                                "firstName": "IvorNot",
-                                                                "lastName": "Bres",
-                                                                "emailAddress": "ivorNot.bres@hostmail.com",
-                                                                "telephone": "+447894056786",
-                                                                "status": "ACTIVE",
-                                                                "sampleUnitType": "BI"}}
+    _respondent_ids = {
+        'f62dfda8-73b0-4e0e-97cf-1b06327a6712': {
+            "id": "f62dfda8-73b0-4e0e-97cf-1b06327a6712",
+            "firstName": "Bhavana",
+            "lastName": "Lincoln",
+            "emailAddress": "lincoln.bhavana@gmail.com",
+            "telephone": "+443069990888",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        'ce12b958-2a5f-44f4-a6da-861e59070a31': {
+            "id": "ce12b958-2a5f-44f4-a6da-861e59070a31",
+            "firstName": "Lars",
+            "lastName": "McEachern",
+            "emailAddress": "mclars@yahoo.com",
+            "telephone": "+443069990413",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        '0a7ad740-10d5-4ecb-b7ca-3c0384afb882': {
+            "id": "0a7ad740-10d5-4ecb-b7ca-3c0384afb882",
+            "firstName": "Vana",
+            "lastName": "Oorschot",
+            "emailAddress": "vana123@aol.com",
+            "telephone": "+443069990289",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        '01b51fcc-ed43-4cdb-ad1c-450f9986859b': {
+            "id": "01b51fcc-ed43-4cdb-ad1c-450f9986859b",
+            "associations": [
+                {
+                    "enrolments": [
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Business Register and Employment Survey",
+                            "surveyId": "33333333-22222-3333-4444-88dc018a1a4c"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Business Register and Employment Survey",
+                            "surveyId": "11111111-22222-3333-4444-88dc018a1a4c"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 1",
+                            "surveyId": "additional_survey_1"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 2",
+                            "surveyId": "additional_survey_2"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 3",
+                            "surveyId": "additional_survey_3"
+                        },
+
+                    ],
+                    "partyId": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
+                    "sampleUnitRef": "50012345678"
+                },
+                {
+                    "enrolments": [
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Business Register and Employment Survey",
+                            "surveyId": "33333333-22222-3333-4444-88dc018a1a4c"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 1",
+                            "surveyId": "additional_survey_1"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 2",
+                            "surveyId": "additional_survey_2"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 3",
+                            "surveyId": "additional_survey_3"
+                        },
+
+                    ],
+                    "partyId": "additional_ru1",
+                    "sampleUnitRef": "50012345678"
+                },
+                {
+                    "enrolments": [
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Business Register and Employment Survey",
+                            "surveyId": "33333333-22222-3333-4444-88dc018a1a4c"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 1",
+                            "surveyId": "additional_survey_1"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 2",
+                            "surveyId": "additional_survey_2"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 3",
+                            "surveyId": "additional_survey_3"
+                        },
+
+                    ],
+                    "partyId": "additional_ru2",
+                    "sampleUnitRef": "50012345678"
+                },
+                {
+                    "enrolments": [
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Business Register and Employment Survey",
+                            "surveyId": "33333333-22222-3333-4444-88dc018a1a4c"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 1",
+                            "surveyId": "additional_survey_1"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 2",
+                            "surveyId": "additional_survey_2"
+                        },
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Additional survey 3",
+                            "surveyId": "additional_survey_3"
+                        },
+
+                    ],
+                    "partyId": "additional_ru3",
+                    "sampleUnitRef": "50012345678"
+                }
+            ],
+            "firstName": "Chandana",
+            "lastName": "Blanchet",
+            "emailAddress": "cblanc@hotmail.co.uk",
+            "telephone": "+443069990854",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        'dd5a38ff-1ecb-4634-94c8-2358df33e614': {
+            "id": "dd5a38ff-1ecb-4634-94c8-2358df33e614",
+            "firstName": "Ida",
+            "lastName": "Larue",
+            "emailAddress": "ilarue47@yopmail.com",
+            "telephone": "+443069990250",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        'AnotherSurvey': {
+            "id": "AnotherSurvey",
+            "firstName": "AnotherSurvey",
+            "lastName": "",
+            "emailAddress": "",
+            "telephone": "",
+            "status": "",
+            "sampleUnitType": "BI"
+        },
+        'ce12b958-2a5f-44f4-a6da-861e59070a32': {
+            "id": "ce12b958-2a5f-44f4-a6da-861e59070a32",
+            "firstName": "Liz",
+            "lastName": "Larkin",
+            "emailAddress": "ilarue47@yopmail.com",
+            "telephone": "+443069990250",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        'db036fd7-ce17-40c2-a8fc-932e7c228397': {
+            "id": "db036fd7-ce17-40c2-a8fc-932e7c228397",
+            "firstName": "Peter",
+            "lastName": "Smith",
+            "emailAddress": "peter.smith@hostmail.com",
+            "telephone": "+447894056785",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        'ab123456-ce17-40c2-a8fc-abcdef123456': {
+            "associations": [
+                {
+                    "enrolments": [
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Business Register and Employment Survey",
+                            "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+                        }
+                    ],
+                    "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+                    "sampleUnitRef": "50012345678"
+                }
+            ],
+            "id": "ab123456-ce17-40c2-a8fc-abcdef123456",
+            "firstName": "Ivor",
+            "lastName": "Bres",
+            "emailAddress": "ivor.bres@hostmail.com",
+            "telephone": "+447894056785",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        '654321ab-ce17-40c2-a8fc-abcdef123456': {
+            "associations": [
+                {
+                    "enrolments": [
+
+                    ],
+                    "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+                    "sampleUnitRef": "50012345678"
+                }
+            ],
+            "id": "654321ab-ce17-40c2-a8fc-abcdef123456",
+            "firstName": "IvorNot",
+            "lastName": "Bres",
+            "emailAddress": "ivorNot.bres@hostmail.com",
+            "telephone": "+447894056786",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        'inactive_user': {
+            "associations": [
+                {
+                    "enrolments": [
+                        {
+                            "enrolmentStatus": "ENABLED",
+                            "name": "Business Register and Employment Survey",
+                            "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+                        }
+                    ],
+                    "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+                    "sampleUnitRef": "50012345678"
+                }
+            ],
+            "id": "inactive_user",
+            "firstName": "Ivor",
+            "lastName": "Bres",
+            "emailAddress": "ivor.bres@hostmail.com",
+            "telephone": "+447894056785",
+            "status": "NOT-ACTIVE",
+            "sampleUnitType": "BI"
+        },
+        'not_enabled': {
+            "associations": [
+                {
+                    "enrolments": [
+                        {
+                            "enrolmentStatus": "NOT_ENABLED",
+                            "name": "Business Register and Employment Survey",
+                            "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+                        }
+                    ],
+                    "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+                    "sampleUnitRef": "50012345678"
+                }
+            ],
+            "id": "not_enabled",
+            "firstName": "Ivor",
+            "lastName": "Bres",
+            "emailAddress": "ivor.bres@hostmail.com",
+            "telephone": "+447894056785",
+            "status": "ACTIVE",
+            "sampleUnitType": "BI"
+        }
+    }

--- a/secure_message/api_mocks/party_service_mock.py
+++ b/secure_message/api_mocks/party_service_mock.py
@@ -24,17 +24,17 @@ class PartyServiceMock:
             user_details = None
         return user_details
 
-    def does_user_have_claim(self, user_id, bus_id, survey_id):
+    def does_user_have_claim(self, user_id, business_id, survey_id):
         user_details = self._respondent_ids[user_id]
         associations = user_details['associations']
-        is_enrolled = self._is_user_enrolled_on_survey(associations, bus_id, survey_id)
+        is_enrolled = self._is_user_enrolled_on_survey(associations, business_id, survey_id)
         return user_details['status'] == 'ACTIVE' and is_enrolled
 
     @staticmethod
-    def _is_user_enrolled_on_survey(associations, bus_id, survey_id):
+    def _is_user_enrolled_on_survey(associations, business_id, survey_id):
         for association in associations:
             surveys = [v['surveyId'] for v in association['enrolments'] if v['enrolmentStatus'] == 'ENABLED']
-            if survey_id in surveys and association['partyId'] == bus_id:
+            if survey_id in surveys and association['partyId'] == business_id:
                 return True
 
         return False

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -52,7 +52,7 @@ class MessageSend(Resource):
         # Validate claim
         if not self._has_valid_claim(g.user, message.data):
             logger.error("Message send failed", error="Invalid claim")
-            return make_response(jsonify("Invalid claim"), 400)
+            return make_response(jsonify("Invalid claim"), 403)
 
         logger.info("Message passed validation")
         self._message_save(message)

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -45,7 +45,7 @@ class MessageSend(Resource):
         post_data['from_internal'] = g.user.is_internal
         message = self._validate_post_data(post_data)
 
-        if message.errors != {}:
+        if message.errors:
             logger.error('Message send failed', errors=message.errors)
             return make_response(jsonify(message.errors), 400)
 

--- a/secure_message/services/party_service.py
+++ b/secure_message/services/party_service.py
@@ -35,6 +35,36 @@ class PartyService:
         return self._get_user_details_from_party_service(uuids)
 
     @staticmethod
+    def does_user_have_claim(user_id, bus_id, survey_id):
+        """Returns true of the user id has a claim on the bus_id, survey_id combination
+         False if not.
+
+         Rather than inspect the respondent data it defers to Party Service for the precise logic
+         to determine what constitutes a valid claim so as to maintain separation of concerns and
+         avoid future maintenance issues.
+        """
+        params = {"respondent_id": user_id, "bus_id": bus_id, "survey_id": survey_id}
+
+        response = requests.get(f"{current_app.config['RAS_PARTY_SERVICE']}party-api/v1/respondents/claim",
+                                auth=current_app.config['BASIC_AUTH'], verify=False, params=urlencode(params))
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            logger.exception('Failed to validate claim data with party service',
+                             status_code=response.status_code,
+                             text=response.text,
+                             respondent_id=user_id,
+                             bus_id=bus_id,
+                             survey_id=survey_id)
+            return []
+
+        logger.info("claim response", response_data=response.content)
+        claim_response = response.content.decode("utf-8")
+        logger.info("Party claim data successfully retrieved ", respondent_id=user_id,
+                    bus_id=bus_id, survey_id=survey_id, response=claim_response)
+        return claim_response.lower() == 'valid'
+
+    @staticmethod
     def _get_user_details_from_party_service(uuids):
         params = urlencode([("id", uuid) for uuid in uuids])
         response = requests.get(f"{current_app.config['RAS_PARTY_SERVICE']}party-api/v1/respondents",

--- a/secure_message/services/party_service.py
+++ b/secure_message/services/party_service.py
@@ -35,15 +35,15 @@ class PartyService:
         return self._get_user_details_from_party_service(uuids)
 
     @staticmethod
-    def does_user_have_claim(user_id, bus_id, survey_id):
-        """Returns true of the user id has a claim on the bus_id, survey_id combination
+    def does_user_have_claim(user_id, business_id, survey_id):
+        """Returns true of the user id has a claim on the business_id, survey_id combination
          False if not.
 
          Rather than inspect the respondent data it defers to Party Service for the precise logic
          to determine what constitutes a valid claim so as to maintain separation of concerns and
          avoid future maintenance issues.
         """
-        params = {"respondent_id": user_id, "bus_id": bus_id, "survey_id": survey_id}
+        params = {"respondent_id": user_id, "business_id": business_id, "survey_id": survey_id}
 
         response = requests.get(f"{current_app.config['RAS_PARTY_SERVICE']}party-api/v1/respondents/claim",
                                 auth=current_app.config['BASIC_AUTH'], verify=False, params=urlencode(params))
@@ -54,14 +54,14 @@ class PartyService:
                              status_code=response.status_code,
                              text=response.text,
                              respondent_id=user_id,
-                             bus_id=bus_id,
+                             business_id=business_id,
                              survey_id=survey_id)
-            return []
+            return False
 
         logger.info("claim response", response_data=response.content)
         claim_response = response.content.decode("utf-8")
         logger.info("Party claim data successfully retrieved ", respondent_id=user_id,
-                    bus_id=bus_id, survey_id=survey_id, response=claim_response)
+                    business_id=business_id, survey_id=survey_id, response=claim_response)
         return claim_response.lower() == 'valid'
 
     @staticmethod

--- a/secure_message/services/service_toggles.py
+++ b/secure_message/services/service_toggles.py
@@ -56,6 +56,9 @@ class Party(ServiceMockToggle):
     def get_users_details(self, uuids):
         return self._service.get_users_details(uuids)
 
+    def does_user_have_claim(self, user_id, bus_id, survey_id):
+        return self._service.does_user_have_claim(user_id, bus_id, survey_id)
+
 
 class InternalUser(ServiceMockToggle):
     """An internal user service mock to authenticate users"""

--- a/secure_message/services/service_toggles.py
+++ b/secure_message/services/service_toggles.py
@@ -56,8 +56,8 @@ class Party(ServiceMockToggle):
     def get_users_details(self, uuids):
         return self._service.get_users_details(uuids)
 
-    def does_user_have_claim(self, user_id, bus_id, survey_id):
-        return self._service.does_user_have_claim(user_id, bus_id, survey_id)
+    def does_user_have_claim(self, user_id, business_id, survey_id):
+        return self._service.does_user_have_claim(user_id, business_id, survey_id)
 
 
 class InternalUser(ServiceMockToggle):

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -37,7 +37,7 @@ class AppTestCase(unittest.TestCase):
                                "role": "internal"}
 
         external_token_data = {constants.USER_IDENTIFIER: AppTestCase.SPECIFIC_EXTERNAL_USER,
-                               "role": "respondent", "claims": [{'bus_id': AppTestCase.TEST_RU,
+                               "role": "respondent", "claims": [{'business_id': AppTestCase.TEST_RU,
                                                                  'surveys': [AppTestCase.BRES_SURVEY]
                                                                  }]
                                }
@@ -82,7 +82,7 @@ class AppTestCase(unittest.TestCase):
                 'thread': "?",
                 'ru_id': 'f1a5e99c-8edf-489a-9c72-6cabe6c387fc',
                 'create_date': datetime.now(timezone.utc),
-                'survey': 'a-survey-id'}
+                'survey': 'a-uuid-for-the-survey'}
 
         response = self.client.post(url, data=json.dumps(data), headers=self.internal_user_header)
         self.assertEqual(response.status_code, 201)  # check post has succeeded

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 from datetime import datetime, timezone
-import uuid
 
 from flask import current_app, json
 from sqlalchemy import create_engine
@@ -18,10 +17,13 @@ from secure_message.common.alerts import AlertViaLogging
 from secure_message.api_mocks.party_service_mock import PartyServiceMock
 
 
-class FlaskTestCase(unittest.TestCase):
+class AppTestCase(unittest.TestCase):
     """Test case for application endpoints"""
 
     BRES_SURVEY = "33333333-22222-3333-4444-88dc018a1a4c"
+    SPECIFIC_INTERNAL_USER = "SpecificInternalUserId"
+    SPECIFIC_EXTERNAL_USER = "0a7ad740-10d5-4ecb-b7ca-3c0384afb882"
+    TEST_RU = 'f1a5e99c-8edf-489a-9c72-6cabe6c387fc'
 
     def setUp(self):
         """setup test environment"""
@@ -31,11 +33,14 @@ class FlaskTestCase(unittest.TestCase):
 
         AlertUser.alert_method = mock.Mock(AlertViaGovNotify)
 
-        internal_token_data = {constants.USER_IDENTIFIER: constants.NON_SPECIFIC_INTERNAL_USER,
+        internal_token_data = {constants.USER_IDENTIFIER: AppTestCase.SPECIFIC_INTERNAL_USER,
                                "role": "internal"}
 
-        external_token_data = {constants.USER_IDENTIFIER: str(uuid.uuid4()),
-                               "role": "respondent"}
+        external_token_data = {constants.USER_IDENTIFIER: AppTestCase.SPECIFIC_EXTERNAL_USER,
+                               "role": "respondent", "claims": [{'bus_id': AppTestCase.TEST_RU,
+                                                                 'surveys': [AppTestCase.BRES_SURVEY]
+                                                                 }]
+                               }
 
         with self.app.app_context():
             internal_signed_jwt = encode(internal_token_data)
@@ -47,7 +52,7 @@ class FlaskTestCase(unittest.TestCase):
         self.external_user_header = {'Content-Type': 'application/json', 'Authorization': external_signed_jwt}
 
         self.test_message = {'msg_to': ['0a7ad740-10d5-4ecb-b7ca-3c0384afb882'],
-                             'msg_from': constants.NON_SPECIFIC_INTERNAL_USER,
+                             'msg_from': AppTestCase.SPECIFIC_INTERNAL_USER,
                              'subject': 'MyMessage',
                              'body': 'hello',
                              'thread_id': "",
@@ -67,24 +72,25 @@ class FlaskTestCase(unittest.TestCase):
 
     def test_that_checks_post_request_is_within_database(self):
         """check messages from messageSend endpoint saved in database correctly"""
-        # check if json message is inside the database
 
         url = "http://localhost:5050/message/send"
 
         data = {'msg_to': ['0a7ad740-10d5-4ecb-b7ca-3c0384afb882'],
-                'msg_from': 'ce12b958-2a5f-44f4-a6da-861e59070a31',
+                'msg_from': AppTestCase.SPECIFIC_INTERNAL_USER,
                 'subject': 'MyMessage',
                 'body': 'hello',
                 'thread': "?",
                 'ru_id': 'f1a5e99c-8edf-489a-9c72-6cabe6c387fc',
                 'create_date': datetime.now(timezone.utc),
-                'read_date': datetime.now(timezone.utc)}
+                'survey': 'a-survey-id'}
 
-        self.client.post(url, data=json.dumps(data), headers=self.internal_user_header)
+        response = self.client.post(url, data=json.dumps(data), headers=self.internal_user_header)
+        self.assertEqual(response.status_code, 201)  # check post has succeeded
 
         with self.engine.connect() as con:
-            request = con.execute('SELECT * FROM securemessage.secure_message WHERE id = (SELECT MAX(id) FROM securemessage.secure_message)')
-            for row in request:
+            db_data = con.execute('SELECT * FROM securemessage.secure_message WHERE id = (SELECT MAX(id) FROM securemessage.secure_message)')
+            self.assertEqual(db_data.rowcount, 1)
+            for row in db_data:
                 data = {"subject": row['subject'], "body": row['body']}
                 self.assertEqual({'subject': 'MyMessage', 'body': 'hello'}, data)
 
@@ -96,9 +102,9 @@ class FlaskTestCase(unittest.TestCase):
         self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)
         engine = create_engine(self.app.config['SECURE_MESSAGING_DATABASE_URL'], echo=True)
         with engine.connect() as con:
-            request = con.execute('SELECT * FROM securemessage.secure_message WHERE id = (SELECT MAX(id) FROM securemessage.secure_message)')
-
-            for row in request:
+            db_data = con.execute('SELECT * FROM securemessage.secure_message WHERE id = (SELECT MAX(id) FROM securemessage.secure_message)')
+            self.assertEqual(db_data.rowcount, 1)
+            for row in db_data:
                 self.assertEqual(len(row['msg_id']), 36)
 
     def test_thread_patch_without_content_type_in_header_fails(self):
@@ -132,8 +138,8 @@ class FlaskTestCase(unittest.TestCase):
 
         engine = create_engine(self.app.config['SECURE_MESSAGING_DATABASE_URL'], echo=True)
         with engine.connect() as con:
-            request = con.execute('SELECT * FROM securemessage.secure_message WHERE id = (SELECT MAX(id) FROM securemessage.secure_message)')
-            for row in request:
+            db_data = con.execute('SELECT * FROM securemessage.secure_message WHERE id = (SELECT MAX(id) FROM securemessage.secure_message)')
+            for row in db_data:
                 self.test_message['thread_id'] = row['thread_id']
 
         # Now submit a new message as a reply , Message Id empty , thread id same as last one
@@ -186,9 +192,9 @@ class FlaskTestCase(unittest.TestCase):
         data = json.loads(response.data)
 
         with self.engine.connect() as con:
-            request = con.execute("SELECT * FROM securemessage.status WHERE label='SENT' AND msg_id='{0}' AND actor='{1}'"
+            db_data = con.execute("SELECT * FROM securemessage.status WHERE label='SENT' AND msg_id='{0}' AND actor='{1}'"
                                   .format(data['msg_id'], self.test_message['survey']))
-            for row in request:
+            for row in db_data:
                 self.assertTrue(row is not None)
 
     def test_message_post_stores_events_correctly_for_message(self):
@@ -199,8 +205,8 @@ class FlaskTestCase(unittest.TestCase):
         data = json.loads(response.data)
 
         with self.engine.connect() as con:
-            request = con.execute(f"SELECT * FROM securemessage.events WHERE event='Sent' AND msg_id='{data['msg_id']}'")
-            for row in request:
+            db_data = con.execute(f"SELECT * FROM securemessage.events WHERE event='Sent' AND msg_id='{data['msg_id']}'")
+            for row in db_data:
                 self.assertTrue(row is not None)
 
     def test_message_post_stores_labels_correctly_for_recipient_of_message(self):
@@ -211,10 +217,10 @@ class FlaskTestCase(unittest.TestCase):
         data = json.loads(response.data)
         # dereferencing msg_to for purpose of test
         with self.engine.connect() as con:
-            request = con.execute("SELECT * FROM securemessage.status WHERE "
+            db_data = con.execute("SELECT * FROM securemessage.status WHERE "
                                   "label='INBOX' OR label='UNREAD' AND msg_id='{0}'"
                                   " AND actor='{1}'".format(data['msg_id'], self.test_message['msg_to'][0]))
-            for row in request:
+            for row in db_data:
                 self.assertTrue(row is not None)
 
     def test_message_post_stores_status_correctly_for_internal_user(self):
@@ -225,10 +231,10 @@ class FlaskTestCase(unittest.TestCase):
         data = json.loads(response.data)
 
         with self.engine.connect() as con:
-            request = con.execute("SELECT * FROM securemessage.status WHERE "
+            db_data = con.execute("SELECT * FROM securemessage.status WHERE "
                                   "msg_id='{0}' AND actor='{1}' AND label='SENT'"
                                   .format(data['msg_id'], self.test_message['survey']))
-            for row in request:
+            for row in db_data:
                 self.assertTrue(row is not None)
 
     @patch.object(PartyServiceMock, 'get_user_details', return_value=({"id": "f62dfda8-73b0-4e0e-97cf-1b06327a6712",

--- a/tests/app/test_mock_party.py
+++ b/tests/app/test_mock_party.py
@@ -51,42 +51,42 @@ class PartyTestCase(unittest.TestCase):
 
     def test_get_does_user_have_claim_returns_true_if_known(self):
         user_id = "ab123456-ce17-40c2-a8fc-abcdef123456"
-        bus_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+        business_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
         survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
         sut = PartyServiceMock()
-        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        result = sut.does_user_have_claim(user_id, business_id, survey_id)
         self.assertTrue(result)
 
-    def test_get_does_user_have_claim_returns_false_for_unknown_bus_id(self):
+    def test_get_does_user_have_claim_returns_false_for_unknown_business_id(self):
         user_id = "ab123456-ce17-40c2-a8fc-abcdef123456"
-        bus_id = "somethingunknown"
+        business_id = "somethingunknown"
         survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
         sut = PartyServiceMock()
-        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        result = sut.does_user_have_claim(user_id, business_id, survey_id)
         self.assertFalse(result)
 
     def test_get_does_user_have_claim_returns_false_for_unknown_survey_id(self):
         user_id = "ab123456-ce17-40c2-a8fc-abcdef123456"
-        bus_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+        business_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
         survey_id = "not known"
         sut = PartyServiceMock()
-        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        result = sut.does_user_have_claim(user_id, business_id, survey_id)
         self.assertFalse(result)
 
     def test_get_does_user_have_claim_returns_false_for_not_active_user(self):
         user_id = "inactive_user"
-        bus_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+        business_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
         survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
         sut = PartyServiceMock()
-        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        result = sut.does_user_have_claim(user_id, business_id, survey_id)
         self.assertFalse(result)
 
     def test_get_does_user_have_claim_returns_false_for_not_enabled(self):
         user_id = "not_enabled"
-        bus_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+        business_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
         survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
         sut = PartyServiceMock()
-        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        result = sut.does_user_have_claim(user_id, business_id, survey_id)
         self.assertFalse(result)
 
 

--- a/tests/app/test_mock_party.py
+++ b/tests/app/test_mock_party.py
@@ -49,6 +49,46 @@ class PartyTestCase(unittest.TestCase):
         result_data = sut.get_business_details(uuid)
         self.assertEqual(result_data, [])
 
+    def test_get_does_user_have_claim_returns_true_if_known(self):
+        user_id = "ab123456-ce17-40c2-a8fc-abcdef123456"
+        bus_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+        survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+        sut = PartyServiceMock()
+        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        self.assertTrue(result)
+
+    def test_get_does_user_have_claim_returns_false_for_unknown_bus_id(self):
+        user_id = "ab123456-ce17-40c2-a8fc-abcdef123456"
+        bus_id = "somethingunknown"
+        survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+        sut = PartyServiceMock()
+        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        self.assertFalse(result)
+
+    def test_get_does_user_have_claim_returns_false_for_unknown_survey_id(self):
+        user_id = "ab123456-ce17-40c2-a8fc-abcdef123456"
+        bus_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+        survey_id = "not known"
+        sut = PartyServiceMock()
+        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        self.assertFalse(result)
+
+    def test_get_does_user_have_claim_returns_false_for_not_active_user(self):
+        user_id = "inactive_user"
+        bus_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+        survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+        sut = PartyServiceMock()
+        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        self.assertFalse(result)
+
+    def test_get_does_user_have_claim_returns_false_for_not_enabled(self):
+        user_id = "not_enabled"
+        bus_id = "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c"
+        survey_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+        sut = PartyServiceMock()
+        result = sut.does_user_have_claim(user_id, bus_id, survey_id)
+        self.assertFalse(result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/behavioural/features/message_post.feature
+++ b/tests/behavioural/features/message_post.feature
@@ -168,18 +168,18 @@ Feature: Message Send Endpoint
     When the message is sent
     Then a bad request status code 400 is returned
 
-  Scenario: Respondent sends a message for an ru they have no claim for , user should receive 400
+  Scenario: Respondent sends a message for an ru they have no claim for , user should receive 403
    Given the user is set as respondent
     And  the from is set to respondent
     And  the to is set to internal specific user
     And the ru is set to 'An ru that they cannot have a claim for'
    When the message is sent
-   Then a bad request status code 400 is returned
+   Then a forbidden status code 403 is returned
 
- Scenario: Respondent sends a message for a survey they have no claim for , user should receive 400
+ Scenario: Respondent sends a message for a survey they have no claim for , user should receive 403
    Given the user is set as respondent
     And  the from is set to respondent
     And  the to is set to internal specific user
     And the survey is set to 'Some survey they cannot have a claim for'
    When the message is sent
-   Then a bad request status code 400 is returned
+   Then a forbidden status code 403 is returned

--- a/tests/behavioural/features/message_post.feature
+++ b/tests/behavioural/features/message_post.feature
@@ -167,3 +167,19 @@ Feature: Message Send Endpoint
       And  the to is set to 'someone_who_does_not_exist'
     When the message is sent
     Then a bad request status code 400 is returned
+
+  Scenario: Respondent sends a message for an ru they have no claim for , user should receive 400
+   Given the user is set as respondent
+    And  the from is set to respondent
+    And  the to is set to internal specific user
+    And the ru is set to 'An ru that they cannot have a claim for'
+   When the message is sent
+   Then a bad request status code 400 is returned
+
+ Scenario: Respondent sends a message for a survey they have no claim for , user should receive 400
+   Given the user is set as respondent
+    And  the from is set to respondent
+    And  the to is set to internal specific user
+    And the survey is set to 'Some survey they cannot have a claim for'
+   When the message is sent
+   Then a bad request status code 400 is returned

--- a/tests/behavioural/features/steps/endpoints.py
+++ b/tests/behavioural/features/steps/endpoints.py
@@ -354,6 +354,16 @@ def step_impl_the_open_threads_count_for_specific_survey_are_counted(context, su
     context.bdd_helper.thread_count = json.loads(response_data)["total"]
 
 
+@when("the count of open threads in default survey is made")
+@given("the count of open threads in default survey is made")
+def step_impl_the_open_threads_count_for_default_survey_are_counted(context):
+    """access the messages_count endpoint to get the count of unread conversations"""
+    url = context.bdd_helper.threads_get_count_url_v2 + f"?survey={context.bdd_helper.default_survey}&is_closed=false"
+    context.response = context.client.get(url, headers=context.bdd_helper.headers)
+    response_data = context.response.data
+    context.bdd_helper.thread_count = json.loads(response_data)["total"]
+
+
 @when("the count of open threads is made")
 @given("the count of open threads is made V2")
 def step_impl_the_open_threads_count_are_counted(context):

--- a/tests/behavioural/features/steps/secure_messaging_context_helper.py
+++ b/tests/behavioural/features/steps/secure_messaging_context_helper.py
@@ -312,6 +312,6 @@ class SecureMessagingContextHelper:
     def use_default_collection_exercise(self):
         self._message_data['collection_exercise'] = SecureMessagingContextHelper.__DEFAULT_COLLECTION_EXERCISE
 
-    def add_additional_respondent_claim(self, bus_id, survey):
+    def add_additional_respondent_claim(self, business_id, survey):
         """Add an ru/survey pair to the additional claims """
-        self.additional_respondent_claims[bus_id] = survey
+        self.additional_respondent_claims[business_id] = survey

--- a/tests/behavioural/features/steps/secure_messaging_context_helper.py
+++ b/tests/behavioural/features/steps/secure_messaging_context_helper.py
@@ -22,6 +22,9 @@ class SecureMessagingContextHelper:
 
     __DEFAULT_SURVEY = '33333333-22222-3333-4444-88dc018a1a4c'
     __ALTERNATE_SURVEY = '11111111-22222-3333-4444-88dc018a1a4c'
+    __ADDITIONAL_SURVEY_1 = 'additional_survey_1'
+    __ADDITIONAL_SURVEY_2 = 'additional_survey_2'
+    __ADDITIONAL_SURVEY_3 = 'additional_survey_3'
 
     __DEFAULT_COLLECTION_CASE = 'collection case1'             # UUID in real use, string for testing clarity
     __ALTERNATE_COLLECTION_CASE = 'AnotherCollectionCase'      # UUID in real use, string for testing clarity
@@ -67,6 +70,7 @@ class SecureMessagingContextHelper:
         self._messages_responses_data = []
         self._last_saved_message_data = None
         self._last_returned_thread_count = 0
+        self.additional_respondent_claims = {}
 
         # Urls
 
@@ -145,6 +149,18 @@ class SecureMessagingContextHelper:
     @property
     def alternate_survey(self):
         return copy.copy(SecureMessagingContextHelper.__ALTERNATE_SURVEY)
+
+    @property
+    def additional_survey_1(self):
+        return copy.copy(SecureMessagingContextHelper.__ADDITIONAL_SURVEY_1)
+
+    @property
+    def additional_survey_2(self):
+        return copy.copy(SecureMessagingContextHelper.__ADDITIONAL_SURVEY_2)
+
+    @property
+    def additional_survey_3(self):
+        return copy.copy(SecureMessagingContextHelper.__ADDITIONAL_SURVEY_3)
 
     @property
     def message_post_url(self):
@@ -268,6 +284,10 @@ class SecureMessagingContextHelper:
     def health_details_endpoint(self):
         return self._health_details_endpoint
 
+    @property
+    def default_ru(self):
+        return copy.copy(self.__DEFAULT_RU)
+
     def use_alternate_ru(self):
         self._message_data['ru_id'] = SecureMessagingContextHelper.__ALTERNATE_RU
 
@@ -291,3 +311,7 @@ class SecureMessagingContextHelper:
 
     def use_default_collection_exercise(self):
         self._message_data['collection_exercise'] = SecureMessagingContextHelper.__DEFAULT_COLLECTION_EXERCISE
+
+    def add_additional_respondent_claim(self, bus_id, survey):
+        """Add an ru/survey pair to the additional claims """
+        self.additional_respondent_claims[bus_id] = survey

--- a/tests/behavioural/features/steps/user.py
+++ b/tests/behavioural/features/steps/user.py
@@ -133,3 +133,27 @@ def step_impl_prepare_to_send_from_rinternal_group_to_respondent(context):
     step_impl_the_user_is_internal_group_user(context)
     step_impl_the_msg_from_is_set_to_internal_group_user(context)
     step_impl_the_msg_to_is_set_to_respondent(context)
+
+
+@given("the respondent has an additional claim for alternate survey on the default ru")
+def step_impl_the_respondent_has_additional_claim_for_alternate_survey_on_default_ru(context):
+    step_impl_the_respondent_has_additional_claim(context, context.bdd_helper.default_ru,
+                                                  context.bdd_helper.alternate_survey)
+
+
+@given("the respondent has an additional claim for survey: '{survey}' on the default ru")
+def step_impl_the_respondent_has_additional_claim_on_default_ru(context, survey):
+    step_impl_the_respondent_has_additional_claim(context, context.bdd_helper.default_ru, survey)
+
+
+@given("the respondent has an additional claim of ru:'{ru}' and survey: '{survey}'")
+def step_impl_the_respondent_has_additional_claim(context, ru, survey):
+    """set the user to the default respondent as saved in the helper"""
+    with context.app.app_context():
+        context.bdd_helper.add_additional_respondent_claim(ru, survey)
+
+
+@given("the respondent has an additional claim for ru: '{ru}' on the default survey")
+def step_impl_the_respondent_has_additional_claim_on_ru_on_default_survey(context, ru):
+    with context.app.app_context():
+        context.bdd_helper.add_additional_respondent_claim(ru, context.bdd_helper.default_survey)

--- a/tests/behavioural/features/v2/threads_count.feature
+++ b/tests/behavioural/features/v2/threads_count.feature
@@ -3,12 +3,12 @@ Feature: Threads count endpoint V2
   Background: Reset database
     Given prepare for tests using 'mock' services
 
-  Scenario Outline: Respondent sending multiple valid messages to group , non specific user should have same number of threads
+  Scenario Outline: Respondent sending multiple valid messages to internal , internal user should have same number of threads
     Given sending from respondent to internal group
-      And the survey is set to 'SomeSurvey'
+      And survey set to default survey
     When '5' messages are sent using V2
       And the user is set as internal <user>
-      And the count of open threads in survey 'SomeSurvey' is made V2
+      And the count of open threads in default survey is made
     Then the returned label count was '5' V2
 
     Examples: user type
@@ -19,12 +19,12 @@ Feature: Threads count endpoint V2
 
 Scenario Outline: Respondent sends multiple messages to internal , some to group/user,  internal reads unread messages , validate threads count
 Given sending from respondent to internal group
-  And the survey is set to 'SomeSurvey'
+  And survey set to default survey
   And '5' messages are sent
   And sending from respondent to internal <user>
   And '4' messages are sent using V2
   And the user is set as internal <user>
-When the count of open threads in survey 'SomeSurvey' is made V2
+  And the count of open threads in default survey is made
 Then the returned label count was '9' V2
 
 Examples: user type
@@ -35,14 +35,14 @@ Examples: user type
 
 Scenario Outline: Respondent sends multiple messages to internal on different surveys internal reads inbox messages , count should be correct for each survey
 Given sending from respondent to internal <user>
-  And the survey is set to 'Survey1'
+  And the survey is set to 'additional_survey_1'
   And '5' messages are sent
-  And the survey is set to 'Survey2'
+  And the survey is set to 'additional_survey_2'
   And '4' messages are sent using V2
-  And the survey is set to 'Survey3'
+  And the survey is set to 'additional_survey_3'
   And '3' messages are sent using V2
   And the user is set as internal <user>
-When the count of open threads in survey 'Survey2' is made V2
+When the count of open threads in survey 'additional_survey_2' is made V2
 Then the thread count is '4' threads
 
 Examples: user type
@@ -127,12 +127,12 @@ Scenario: Respondent sends messages to different cc, internal user filters by cc
 
 Scenario: Respondent sends messages to different ru, internal user filters by ru
   Given sending from respondent to internal specific user
-    And the ru is set to 'ru1'
+    And the ru is set to 'additional_ru1'
     And the message is sent V2
-    And the ru is set to 'ru1'
+    And the ru is set to 'additional_ru1'
     And the message is sent V2
-    And the ru is set to 'ru2'
+    And the ru is set to 'additional_ru2'
     And the message is sent V2
   When  the user is set as internal specific user
-    And the count of open threads for current user and ru of 'ru1' is made
+    And the count of open threads for current user and ru of 'additional_ru1' is made
   Then  the thread count is '2' threads

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -120,24 +120,24 @@ Feature: Get threads list Endpoint V2
                     each with different survey_id validate , that only 2 messages returned when we restrict by survey
 
     Given sending from respondent to internal <user>
-      And the survey is set to 'Survey1'
+      And the survey is set to 'additional_survey_1'
       And the message is sent V2
       And the thread id is set to the last returned thread id
       And the message is sent V2
 
       And the thread_id is set to empty
-      And the survey is set to 'Survey2'
+      And the survey is set to 'additional_survey_2'
       And the message is sent V2
       And the thread id is set to the last returned thread id
       And the message is sent V2
 
       And the thread_id is set to empty
-      And the survey is set to 'Survey1'
+      And the survey is set to 'additional_survey_1'
       And the message is sent V2
       And the thread id is set to the last returned thread id
       And the message is sent V2
 
-    When the threads in survey 'Survey1' are read
+    When the threads in survey 'additional_survey_1' are read
     Then  a success status code 200 is returned
       And  '2' messages are returned
 
@@ -184,24 +184,24 @@ Feature: Get threads list Endpoint V2
                     each with different ru validate , that only 2 messages returned when we restrict by ru
 
     Given sending from respondent to internal <user>
-      And the ru is set to 'ru1'
+      And the ru is set to 'additional_ru1'
       And the message is sent V2
       And the thread id is set to the last returned thread id
       And the message is sent V2
 
       And the thread_id is set to empty
-      And the ru is set to 'ru2'
+      And the ru is set to 'additional_ru2'
       And the message is sent V2
       And the thread id is set to the last returned thread id
       And the message is sent V2
 
       And the thread_id is set to empty
-      And the ru is set to 'ru1'
+      And the ru is set to 'additional_ru1'
       And the message is sent V2
       And the thread id is set to the last returned thread id
       And the message is sent V2
 
-    When the threads with ru 'ru1' are read
+    When the threads with ru 'additional_ru1' are read
     Then  a success status code 200 is returned
       And  '2' messages are returned
 


### PR DESCRIPTION
**What is the context of this PR?**
There was no validation that a user had a claim on a survey/ru. Which meant that if a valid user had a url they could send a message in a conversation that they should not be able to. This change validates the claim prior to being able to post a message .


Link to Trello card

This change is the second attempt. The first used claims passed in the JWT, however it was discovered that this failed at a level of survey/ru combinations that was not significantly higher than that in production, and although it was a cleaner design it could be an insidious bug. Therefore it was decided to add an end point to party and have secure message validate the claim prior to message post. Other endpoints did not need such protection, get for example uses the user id as part of the query. 

Having decided to use party , the decision was then how to decide. Party already exposed a get which returned all the associations. We could have walked these . However that would have meant that knowledge about what constituted a valid or invalid claim would then be in secure message , so it would would be a separation of concerns issue and led to more coupling between the services. Since this is only being called on message post which is a relatively infrequent event it was decided to provide a new end point in party purely to validate a claim. 

**How to review**
Run the unit and behave tests . This has added extra functionality to the message post which is covered by tests in this repo and it only returns status codes that it already returned so there should be no need to create an acceptance test for this. However it is possibly worthwhile confirming this by running the acceptance tests
