### PR TITLE
403 forbidden access to secure message

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@ class Config:
     All configuration may be overridden by setting the appropriate environment variable name.
     """
     NAME = os.getenv('NAME', 'ras-secure-message')
-    VERSION = os.getenv('VERSION', '0.12.0')
+    VERSION = os.getenv('VERSION', '0.14.0')
 
     SECURE_MESSAGING_DATABASE_URL = os.getenv(
         'SECURE_MESSAGING_DATABASE_URL', 'postgresql://postgres:postgres@localhost:5432')

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from flask import current_app
 from sqlalchemy import create_engine
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, Forbidden
 
 from secure_message.application import create_app
 from secure_message.common.eventsapi import EventsApi
@@ -400,11 +400,11 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
                 self.assertIsNotNone(second_respondent_thread)
 
                 # first respondent shouldn't be able to retrieve second respondent's message
-                with self.assertRaises(NotFound):
+                with self.assertRaises(Forbidden):
                     Retriever.retrieve_thread(first_respondent_thread_id, self.second_user_respondent)
 
                 # second respondent shouldn't be able to retrieve first respondent's message
-                with self.assertRaises(NotFound):
+                with self.assertRaises(Forbidden):
                     Retriever.retrieve_thread(second_respondent_thread_id, self.user_respondent)
 
 

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -390,4 +390,4 @@ Feature: Get threads list Endpoint V2
       And   the thread id is set to the last returned thread id
     When the user is set as alternative respondent
      And  the thread is read
-    Then a not found status code 404 is returned
+    Then  forbidden status code 403 is returned

--- a/tests/behavioural/features/v2/threads_get.feature
+++ b/tests/behavioural/features/v2/threads_get.feature
@@ -390,4 +390,4 @@ Feature: Get threads list Endpoint V2
       And   the thread id is set to the last returned thread id
     When the user is set as alternative respondent
      And  the thread is read
-    Then  forbidden status code 403 is returned
+    Then  a forbidden status code 403 is returned


### PR DESCRIPTION
Made change to frontstage to show 403 error when accessing message that does not belong to the user. Had to make the change to return a 403 rather than a 404 in secure message.

https://trello.com/c/iWD6OxY9/824-403-message-thread-not-found-status-page-3


**How to review**
 runtests in secure message
