### PR TITLE
Change a lot of logging from error to info

### DIFF
--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -165,7 +165,7 @@ class Retriever:
         try:
             result = db_model.query.filter_by(msg_id=message_id).first()
             if result is None:
-                logger.error('Message ID not found', message_id=message_id)
+                logger.info('Message ID not found', message_id=message_id)
                 raise NotFound(description=f"Message with msg_id '{message_id}' does not exist")
         except SQLAlchemyError:
             logger.exception('Error retrieving message from database')
@@ -197,7 +197,7 @@ class Retriever:
                 .order_by(SecureMessage.id.desc())
 
             if not result.all():
-                logger.error('Thread found, but respondent does not have access', thread_id=thread_id,
+                logger.info('Thread found, but respondent does not have access', thread_id=thread_id,
                              user_id=user.user_uuid)
                 raise Forbidden(
                     description=f"User {user.user_uuid} is not authorised to view conversation with thread_id: "
@@ -225,7 +225,7 @@ class Retriever:
                 .order_by(Status.id.desc())
 
             if not result.all():
-                logger.error('Thread not retrieved for internal user', thread_id=thread_id)
+                logger.info('Thread not retrieved for internal user', thread_id=thread_id)
                 raise NotFound(description=f"Conversation with thread_id {thread_id} not retrieved")
 
         except SQLAlchemyError:

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -198,7 +198,7 @@ class Retriever:
 
             if not result.all():
                 logger.info('Thread found, but respondent does not have access', thread_id=thread_id,
-                             user_id=user.user_uuid)
+                            user_id=user.user_uuid)
                 raise Forbidden(
                     description=f"User {user.user_uuid} is not authorised to view conversation with thread_id: "
                                 f"'{thread_id}'")

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -46,12 +46,12 @@ class MessageSend(Resource):
         message = self._validate_post_data(post_data)
 
         if message.errors:
-            logger.error('Message send failed', errors=message.errors)
+            logger.info('Message send failed', errors=message.errors)
             return make_response(jsonify(message.errors), 400)
 
         # Validate claim
         if not self._has_valid_claim(g.user, message.data):
-            logger.error("Message send failed", error="Invalid claim")
+            logger.info("Message send failed", error="Invalid claim")
             return make_response(jsonify("Invalid claim"), 403)
 
         logger.info("Message passed validation")
@@ -180,25 +180,25 @@ class MessageModifyById(Resource):
     def _validate_request(request_data):
         """Used to validate data within request body for ModifyById"""
         if 'label' not in request_data:
-            logger.error('No label provided')
+            logger.info('No label provided')
             raise BadRequest(description="No label provided")
 
         label = request_data["label"]
         if label not in Labels.label_list.value:  # NOQA pylint:disable=unsupported-membership-test
-            logger.error('Invalid label provided', label=label)
+            logger.info('Invalid label provided', label=label)
             raise BadRequest(description=f"Invalid label provided: {label}")
 
         if label != Labels.UNREAD.value:
-            logger.error('Non modifiable label provided', label=label)
+            logger.info('Non modifiable label provided', label=label)
             raise BadRequest(description=f"Non modifiable label provided: {label}")
 
         if 'action' not in request_data:
-            logger.error('No action provided')
+            logger.info('No action provided')
             raise BadRequest(description="No action provided")
 
         action = request_data["action"]
         if action not in ["add", "remove"]:
-            logger.error('Invalid action requested', action=action)
+            logger.info('Invalid action requested', action=action)
             raise BadRequest(description=f"Invalid action requested: {action}")
 
         return action, label

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -77,13 +77,13 @@ class ThreadById(Resource):
         bound_logger = logger.bind(thread_id=metadata.id, user_uuid=g.user.user_uuid)
         # Check if it's empty
         if not request_data:
-            bound_logger.error('No properties provided')
+            bound_logger.info('No properties provided')
             raise BadRequest(description="No properties provided")
         if 'is_closed' not in request_data:
-            bound_logger.error('Invalid properties provided')
+            bound_logger.info('Invalid properties provided')
             raise BadRequest(description="Only 'is_closed' property may be provided")
         if not isinstance(request_data['is_closed'], bool):
-            bound_logger.error('Invalid value provided')
+            bound_logger.info('Invalid value provided')
             raise BadRequest(description="Invalid value provided")
         if metadata.is_closed and request_data['is_closed'] is True:
             bound_logger.info("Conversation already closed")
@@ -118,7 +118,7 @@ class ThreadList(Resource):
     @staticmethod
     def _validate_request(request_args, user):
         if request_args.my_conversations and user.is_respondent:
-            logger.error('My conversations option not available to respondents', user_uuid=user.user_uuid)
+            logger.info('My conversations option not available to respondents', user_uuid=user.user_uuid)
             raise BadRequest(description="My conversations option not available to respondents")
 
 

--- a/secure_message/validation/domain.py
+++ b/secure_message/validation/domain.py
@@ -64,7 +64,7 @@ class MessageSchema(Schema):
     @validates_schema
     def validate_to_from_not_equal(self, data):   # NOQA pylint:disable=no-self-use
         if 'msg_to' in data.keys() and 'msg_from' in data.keys() and data['msg_to'][0] == data['msg_from']:
-            logger.error('Message to and message from cannot be the same', message_to=data['msg_to'][0], message_from=data['msg_from'])
+            logger.info('Message to and message from cannot be the same', message_to=data['msg_to'][0], message_from=data['msg_from'])
             raise ValidationError("msg_to and msg_from fields can not be the same.")
 
     @validates("msg_to")
@@ -73,11 +73,11 @@ class MessageSchema(Schema):
             self.validate_non_zero_field_length("msg_to", len(item), constants.MAX_TO_LEN)
             if g.user.is_internal:  # internal user must be sending to a respondent
                 if not g.user.is_valid_respondent(item):
-                    logger.error('Not a valid respondent', user=item)
+                    logger.info('Not a valid respondent', user=item)
                     raise ValidationError(f"{item} is not a valid respondent.")
             else:  # Respondent sending to internal
                 if not (msg_to[0] == constants.NON_SPECIFIC_INTERNAL_USER or g.user.is_valid_internal_user(msg_to[0])):
-                    logger.error('Not a valid internal user', user=item)
+                    logger.info('Not a valid internal user', user=item)
                     raise ValidationError(f"{item} is not a valid internal user.")
 
     @validates("msg_from")
@@ -85,8 +85,8 @@ class MessageSchema(Schema):
         self.validate_non_zero_field_length("msg_from", len(msg_from), constants.MAX_FROM_LEN)
 
         if msg_from != g.user.user_uuid:
-            logger.error('Users can only send messages from themselves',
-                         message_from=msg_from, user_uuid=g.user.user_uuid)
+            logger.info('Users can only send messages from themselves',
+                        message_from=msg_from, user_uuid=g.user.user_uuid)
             raise ValidationError(f"You are not authorised to send a message on behalf of user or work group {msg_from}")
 
     @validates("body")
@@ -126,12 +126,12 @@ class MessageSchema(Schema):
     @staticmethod
     def validate_not_present(data, field_name):
         if field_name in data.keys():
-            logger.error('Field cannot be set', field_name=field_name)
+            logger.info('Field cannot be set', field_name=field_name)
             raise ValidationError(f"{field_name} can not be set")
 
     def validate_non_zero_field_length(self, field_name, length, max_field_len):
         if length <= 0:
-            logger.error('Field not populated', field_name=field_name)
+            logger.info('Field not populated', field_name=field_name)
             if field_name == "Body":
                 field_name = "message"
             raise ValidationError(f'Please enter a {field_name.lower()}')
@@ -140,5 +140,5 @@ class MessageSchema(Schema):
     @staticmethod
     def validate_field_length(field_name, length, max_field_len, data=None):
         if length > max_field_len:
-            logger.error('Field is too large', field_name=field_name, length=length, max_field_len=max_field_len)
+            logger.info('Field is too large', field_name=field_name, length=length, max_field_len=max_field_len)
             raise ValidationError(f'{field_name} field length must not be greater than {max_field_len}', field_name, [], data)


### PR DESCRIPTION
**What is the context of this PR?**

https://trello.com/c/XMxhigG8

We were getting alerts because of the number of errors that were being thrown.  A lot of the errors in secure message can be put to info level as we should only have things at the error level that are actionable (databases failing, tokens not decoding, missing config items, etc).  Things that aren't actionable (api being called with wrong parameters, trying to close closed conversations, etc) don't need to be errors as the user will have the appropriate error screen presented to them as this api returns sensible http status codes in the response.

**How to review**

- Unit tests still pass.
- Check all the changed files to make sure nothing was mistakenly changed
- Check all the remaining logger.error lines to make sure that only sensible ones have been left.
