### PR TITLE
Cannot reply to deleted message

### DIFF
--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -32,9 +32,6 @@ class MessageSend(Resource):
             logger.info('Request must set accept content type "application/json" in header.')
         post_data = request.get_json(force=True)
 
-        logger.info("Here!!!!!!!!!--------------!!!!!!!!!here")
-        logger.info(post_data)
-
         if 'msg_id' in post_data:
             raise BadRequest(description="Message can not include msg_id")
         if post_data.get('thread_id'):
@@ -49,7 +46,6 @@ class MessageSend(Resource):
             # assume that it's fine if it's empty.
             if conversation_metadata and conversation_metadata.is_closed:
                 raise BadRequest(description="Cannot reply to a closed conversation")
-
 
         post_data['from_internal'] = g.user.is_internal
         message = self._validate_post_data(post_data)

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -32,21 +32,6 @@ class MessageSend(Resource):
             logger.info('Request must set accept content type "application/json" in header.')
         post_data = request.get_json(force=True)
 
-        if 'msg_id' in post_data:
-            raise BadRequest(description="Message can not include msg_id")
-        if post_data.get('thread_id'):
-            if g.user.is_internal and not party.get_users_details(post_data['msg_to']):
-                # If an internal person is sending a message to a respondent, we need to check that they exist.
-                # If they don't exist (because they've been deleted) then we raise a NotFound exception as the
-                # respondent can't be found in the system.
-                raise NotFound(description="Respondent not found")
-            conversation_metadata = Retriever.retrieve_conversation_metadata(post_data.get('thread_id'))
-            # Ideally, we'd return a 404 if there isn't a record in the conversation table.  But until we
-            # ensure there is a record in here for every thread_id in the secure_message table, we just have to
-            # assume that it's fine if it's empty.
-            if conversation_metadata and conversation_metadata.is_closed:
-                raise BadRequest(description="Cannot reply to a closed conversation")
-
         post_data['from_internal'] = g.user.is_internal
         message = self._validate_post_data(post_data)
 
@@ -83,7 +68,24 @@ class MessageSend(Resource):
 
     @staticmethod
     def _validate_post_data(post_data):
+        if 'msg_id' in post_data:
+            raise BadRequest(description="Message can not include msg_id")
+
         message = MessageSchema().load(post_data)
+
+        if post_data.get('thread_id'):
+            if post_data['from_internal'] and not party.get_users_details(post_data['msg_to']):
+                # If an internal person is sending a message to a respondent, we need to check that they exist.
+                # If they don't exist (because they've been deleted) then we raise a NotFound exception as the
+                # respondent can't be found in the system.
+                raise NotFound(description="Respondent not found")
+
+            conversation_metadata = Retriever.retrieve_conversation_metadata(post_data.get('thread_id'))
+            # Ideally, we'd return a 404 if there isn't a record in the conversation table.  But until we
+            # ensure there is a record in here for every thread_id in the secure_message table, we just have to
+            # assume that it's fine if it's empty.
+            if conversation_metadata and conversation_metadata.is_closed:
+                raise BadRequest(description="Cannot reply to a closed conversation")
         return message
 
     @staticmethod

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -3,7 +3,7 @@ import logging
 from flask import request, jsonify, g, current_app, make_response
 from flask_restful import Resource
 from structlog import wrap_logger
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, NotFound
 
 from secure_message import constants
 from secure_message.common.alerts import AlertUser, AlertViaGovNotify, AlertViaLogging
@@ -32,15 +32,24 @@ class MessageSend(Resource):
             logger.info('Request must set accept content type "application/json" in header.')
         post_data = request.get_json(force=True)
 
+        logger.info("Here!!!!!!!!!--------------!!!!!!!!!here")
+        logger.info(post_data)
+
         if 'msg_id' in post_data:
             raise BadRequest(description="Message can not include msg_id")
         if post_data.get('thread_id'):
+            if g.user.is_internal and not party.get_users_details(post_data['msg_to']):
+                # If an internal person is sending a message to a respondent, we need to check that they exist.
+                # If they don't exist (because they've been deleted) then we raise a NotFound exception as the
+                # respondent can't be found in the system.
+                raise NotFound(description="Respondent not found")
             conversation_metadata = Retriever.retrieve_conversation_metadata(post_data.get('thread_id'))
             # Ideally, we'd return a 404 if there isn't a record in the conversation table.  But until we
             # ensure there is a record in here for every thread_id in the secure_message table, we just have to
             # assume that it's fine if it's empty.
             if conversation_metadata and conversation_metadata.is_closed:
                 raise BadRequest(description="Cannot reply to a closed conversation")
+
 
         post_data['from_internal'] = g.user.is_internal
         message = self._validate_post_data(post_data)

--- a/tests/behavioural/features/message_post.feature
+++ b/tests/behavioural/features/message_post.feature
@@ -147,7 +147,6 @@ Feature: Message Send Endpoint
     When the message is sent
     Then a bad request status code 400 is returned
 
-
   Scenario: Respondent sends a message with a msg_id
     Given sending from respondent to internal specific user
       And  the msg_id is set to '12345678'
@@ -203,3 +202,10 @@ Feature: Message Send Endpoint
     And the survey is set to 'Some survey they cannot have a claim for'
    When the message is sent
    Then a forbidden status code 403 is returned
+
+  Scenario: Internal user sending a message with a non-existent a 404 error
+    Given the user is set as internal
+    And the to is set to a deleted respondent
+    And the thread_id is set to '9fef9d17-8846-48bc-ab4d-dc8af4197e95'
+    When the message is sent
+    Then a not found status code 404 is returned

--- a/tests/behavioural/features/steps/secure_messaging_context_helper.py
+++ b/tests/behavioural/features/steps/secure_messaging_context_helper.py
@@ -48,6 +48,10 @@ class SecureMessagingContextHelper:
     __ALTERNATIVE_RESPONDENT_USER_TOKEN = {constants.USER_IDENTIFIER: __ALTERNATIVE_RESPONDENT_USER_ID,
                                            "role": "respondent"}
 
+    __DELETED_RESPONDENT_USER_ID = "778f60f6-5b5f-4617-b71b-26c0607c769c"
+    __DELETED_RESPONDENT_USER_TOKEN = {constants.USER_IDENTIFIER: __DELETED_RESPONDENT_USER_ID,
+                                       "role": "respondent"}
+
     __BASE_URL = "http://localhost:5050"
 
     __default_message_data = data = {'msg_to': ['0a7ad740-10d5-4ecb-b7ca-3c0384afb882'],

--- a/tests/behavioural/features/steps/secure_messaging_context_helper.py
+++ b/tests/behavioural/features/steps/secure_messaging_context_helper.py
@@ -137,6 +137,10 @@ class SecureMessagingContextHelper:
         return copy.deepcopy(SecureMessagingContextHelper.__ALTERNATIVE_RESPONDENT_USER_TOKEN)
 
     @property
+    def deleted_respondent_user_token(self):
+        return copy.deepcopy(SecureMessagingContextHelper.__DELETED_RESPONDENT_USER_TOKEN)
+
+    @property
     def default_survey(self):
         return copy.copy(SecureMessagingContextHelper.__DEFAULT_SURVEY)
 
@@ -187,6 +191,10 @@ class SecureMessagingContextHelper:
     @property
     def alternative_respondent_id(self):
         return copy.copy(SecureMessagingContextHelper.__ALTERNATIVE_RESPONDENT_USER_ID)
+
+    @property
+    def deleted_respondent_id(self):
+        return copy.copy(SecureMessagingContextHelper.__DELETED_RESPONDENT_USER_ID)
 
     @property
     def internal_id_specific_user(self):

--- a/tests/behavioural/features/steps/to_field.py
+++ b/tests/behavioural/features/steps/to_field.py
@@ -39,6 +39,13 @@ def step_impl_the_msg_to_is_set_to_alternative_respondent(context):
     step_impl_the_msg_to_is_set_to(context, context.bdd_helper.alternative_respondent_id)
 
 
+@given("the to is set to a deleted respondent")
+@when("the to is set to a deleted respondent")
+def step_impl_the_msg_to_is_set_to_deleted_respondent(context):
+    """ set the msg to field in the message data to the respondent as specified in the helper"""
+    step_impl_the_msg_to_is_set_to(context, context.bdd_helper.deleted_respondent_id)
+
+
 @given("the to is set to respondent as a string not array")
 @when("the to is set to respondent as a string not array")
 def step_impl_the_msg_to_is_set_to_respondent_as_string_not_array(context):


### PR DESCRIPTION
**What is the context of this PR?**

It's not possible to reply to deleted users.  A similar change has been made in response-operations-ui, but we need to do a check here incase the client gets around this restriction.  

https://trello.com/c/3TkwE4E8

Describe what you have changed and why, link to other PRs or Issues as appropriate.

**How to review**
Follow the 'test additional logic' part of the guide in https://github.com/ONSdigital/response-operations-ui/pull/371 Testing that will test this as secure-message is the part that generates the 404
