### PR TITLE
Return multiple counts

### DIFF
--- a/API.md
+++ b/API.md
@@ -444,6 +444,10 @@ Available search criteria matches those on get threads:
 * is_closed - If set true then only closed conversations will be considered. Defaults to false if omitted.
 * my_conversations - If set true then will only return conversations where the currently signed in user is an actor in the last message of the conversation.
 * new_respondent_conversations - If set true then only counts new conversations by the respondent. I.e ones not replied to
+* all_conversation_types - If set true will override is_closed, my_conversations and new_respondent_conversations
+  in the count end point, and return 4 counts for open, close, my_conversations and new_respondent_conversations.
+  Slower than asking for a specific conversation type so only use where all 4 counts are needed. 
+  Use specific counts if they suffice.
 * business_id - If set then restrict conversations to those regarding a specific ru
 * cc - If set then restricts the conversations to a specific collection case
 * ce - If set then restricts the conversations to a specific collction exercise

--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -14,7 +14,26 @@ MessageArgs = collections.namedtuple(
 
 
 def get_options(args):
-    """extract options from request , allow label to be set by caller"""
+    """extract options from request , allow label to be set by caller
+
+    :param args, contains search arguments. Not all end points support all args
+    :returns MessageArgs named tuple containing the args for the search
+
+    business_id If set , restricts search to conversations regarding this specific party id
+    surveys  If set allows the count to be restricted by a list of survey_ids
+    cc  If set , allows the count to be restricted by a particular  case
+    ce  If set, alows the count to be restricted by a particular collection exercise
+    is_closed If set to 'true' only counts closed conversations, else only open conversations
+    my_conversations If set to 'true only counts my conversations.
+        I.e conversations where the current user id is the to actor id
+    new_respondent_conversations If set to 'true'only counts conversations where the to actor is set to 'GROUP'
+    all_conversation_types If set 'true', overrides is_closed, my_conversations and new_respondent_conversations
+        and returns 4 counts 1 for each of , open , closed, my_conversations and new_respondent_conversations
+    page If set requests the specific page of information to return
+    limit If set it sets the maximum number of results to return
+    desc If present, requests the information in descending order
+
+    """
 
     fields = {'page': 1, 'limit': MESSAGE_QUERY_LIMIT, 'business_id': None, 'surveys': None,
               'desc': True, 'cc': None, 'label': None, 'ce': None, 'is_closed': False,

--- a/secure_message/common/utilities.py
+++ b/secure_message/common/utilities.py
@@ -10,7 +10,7 @@ from secure_message.services.service_toggles import party, internal_user_service
 logger = wrap_logger(logging.getLogger(__name__))
 MessageArgs = collections.namedtuple(
     'MessageArgs',
-    'page limit business_id surveys cc label desc ce is_closed my_conversations new_respondent_conversations')
+    'page limit business_id surveys cc label desc ce is_closed my_conversations new_respondent_conversations all_conversation_types')
 
 
 def get_options(args):
@@ -18,7 +18,7 @@ def get_options(args):
 
     fields = {'page': 1, 'limit': MESSAGE_QUERY_LIMIT, 'business_id': None, 'surveys': None,
               'desc': True, 'cc': None, 'label': None, 'ce': None, 'is_closed': False,
-              'my_conversations': False, 'new_respondent_conversations': False}
+              'my_conversations': False, 'new_respondent_conversations': False, 'all_conversation_types': False}
 
     for field in ['cc', 'ce', 'business_id', 'label']:
         if args.get(field):
@@ -42,11 +42,34 @@ def get_options(args):
     if args.get('new_respondent_conversations') == 'true':
         fields['new_respondent_conversations'] = True
 
+    if args.get('all_conversation_types') == 'true':
+        fields['all_conversation_types'] = True
+
     return MessageArgs(page=fields['page'], limit=fields['limit'], business_id=fields['business_id'],
                        surveys=fields['surveys'], cc=fields['cc'], label=fields['label'],
                        desc=fields['desc'], ce=fields['ce'], is_closed=fields['is_closed'],
                        my_conversations=fields['my_conversations'],
-                       new_respondent_conversations=fields['new_respondent_conversations'])
+                       new_respondent_conversations=fields['new_respondent_conversations'],
+                       all_conversation_types=fields['all_conversation_types'])
+
+
+def set_conversation_type_args(existing_args, is_closed=False, my_conversations=False, new_conversations=False,
+                               all_types=False):
+    """Returns a new set of args based on the existing args which are a named tuple,
+    but allow the conversation type only to be changed"""
+
+    return MessageArgs(page=existing_args.page,
+                       limit=existing_args.limit,
+                       business_id=existing_args.business_id,
+                       surveys=existing_args.surveys,
+                       cc=existing_args.cc,
+                       label=existing_args.label,
+                       desc=existing_args.desc,
+                       ce=existing_args.ce,
+                       is_closed=is_closed,
+                       my_conversations=my_conversations,
+                       new_respondent_conversations=new_conversations,
+                       all_conversation_types=all_types)
 
 
 def generate_string_query_args(args):

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -85,7 +85,7 @@ class Retriever:
 
         totals = {}
 
-        args = set_conversation_type_args(request_args, is_closed=False)  # is_closed shown simply for clarity
+        args = set_conversation_type_args(request_args)  # is_closed defaults to False
         totals['open'] = Retriever.thread_count_by_survey(args, user)
 
         args = set_conversation_type_args(request_args, is_closed=True)

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -10,6 +10,7 @@ from werkzeug.exceptions import InternalServerError, NotFound, Forbidden
 from secure_message.constants import NON_SPECIFIC_INTERNAL_USER
 from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
+from secure_message.common.utilities import set_conversation_type_args
 from secure_message.repository.database import Conversation, db, Events, SecureMessage, Status
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -73,6 +74,30 @@ class Retriever:
             logger.error('Error retrieving count of threads by survey from database', error=e)
             raise InternalServerError(description="Error retrieving count of threads from database")
         return result
+
+    @staticmethod
+    def thread_count_by_survey_and_conversation_states(request_args, user):
+        """Return 4 conversation counts. They are for open, closed, my conversations and
+        new_respondent_conversation.
+        Given each of these counts uses different clauses to define them and they are not mutually exclusive,
+        they are difficult to achieve with the current db structure in a single query, hence this submits 4 db queries.
+        """
+
+        totals = {}
+
+        args = set_conversation_type_args(request_args, is_closed=False)  # is_closed shown simply for clarity
+        totals['open'] = Retriever.thread_count_by_survey(args, user)
+
+        args = set_conversation_type_args(request_args, is_closed=True)
+        totals['closed'] = Retriever.thread_count_by_survey(args, user)
+
+        args = set_conversation_type_args(request_args, my_conversations=True)
+        totals['my_conversations'] = Retriever.thread_count_by_survey(args, user)
+
+        args = set_conversation_type_args(request_args, new_conversations=True)
+        totals['new_respondent_conversations'] = Retriever.thread_count_by_survey(args, user)
+
+        return totals
 
     @staticmethod
     def retrieve_thread_list(user, request_args):

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -129,21 +129,9 @@ class ThreadList(Resource):
 class ThreadCounter(Resource):
     """Get count of all conversations for a specific internal user
     Typically for a specific survey, supports filtering by case, collection exercise, business party id etc
-    Args:
-        business_id If set , restricts search to conversations regarding this specific party id
-        surveys  If set allows the count to be restricted by a list of survey_ids
-        cc  If set , allows the count to be restricted by a particular  case
-        ce  If set, alows the count to be restricted by a particular collection exercise
-        is_closed If set to 'true' only counts closed conversations, else only open conversations
-        my_conversations If set to 'true only counts my conversations.
-            I.e conversations where the current user id is the to actor id
-        new_respondent_conversations If set to 'true'only counts conversations where the to actor is set to 'GROUP'
-        all_conversation_types If set 'true', overrides is_closed, my_conversations and new_respondent_conversations and
-            returns 4 counts 1 for each of , open , closed, my_conversations and new_respondent_conversations
 
-    Returns:
-        if all_conversation_types is set 'true' returns json representing all 4 counts
-        else returns the count for the single type combination requested.
+    :returns if all_conversation_types is set 'true' returns json representing all 4 counts
+              else returns the count for the single type combination requested.
     """
     @staticmethod
     def get():

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -317,7 +317,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
             surveys=[self.BRES_SURVEY],
             is_closed=False,
             my_conversations=False,
-            new_respondent_conversations=False)
+            new_respondent_conversations=False,
+            all_conversation_types=False)
 
         for _ in range(5):
             self.create_thread(no_of_messages=2)
@@ -347,7 +348,8 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
             surveys=[self.BRES_SURVEY],
             is_closed=False,
             my_conversations=True,
-            new_respondent_conversations=False)
+            new_respondent_conversations=False,
+            all_conversation_types=False)
 
         for _ in range(5):
             self.create_thread(no_of_messages=2)

--- a/tests/app/test_utilities.py
+++ b/tests/app/test_utilities.py
@@ -8,7 +8,7 @@ from secure_message.services.service_toggles import party, internal_user_service
 
 
 def get_args(page=1, limit=100, surveys=None, cc="", ru="", label="", desc=True, ce="", is_closed=False,
-             my_conversations=False, new_respondent_conversations=False):
+             my_conversations=False, new_respondent_conversations=False, all_conversation_types=False):
     return MessageArgs(page=page,
                        limit=limit,
                        surveys=surveys,
@@ -19,7 +19,8 @@ def get_args(page=1, limit=100, surveys=None, cc="", ru="", label="", desc=True,
                        ce=ce,
                        is_closed=is_closed,
                        my_conversations=my_conversations,
-                       new_respondent_conversations=new_respondent_conversations)
+                       new_respondent_conversations=new_respondent_conversations,
+                       all_conversation_types=all_conversation_types)
 
 
 class UtilitiesTestCase(unittest.TestCase):

--- a/tests/behavioural/features/steps/common.py
+++ b/tests/behavioural/features/steps/common.py
@@ -56,8 +56,30 @@ def step_impl_n_messages_returned(context, message_count):
 
 
 @then("the thread count is '{thread_count}' threads")
-def sep_impl_thread_count_validate(context, thread_count):
+def step_impl_thread_count_validate(context, thread_count):
     nose.tools.assert_equal(int(thread_count), context.bdd_helper.thread_count)
+
+
+@then("the thread open count is '{thread_count}' threads")
+def step_impl_open_thread_count_validate(context, thread_count):
+    nose.tools.assert_equal(int(thread_count), context.bdd_helper.thread_counts_all_conversation_types['open'])
+
+
+@then("the thread closed count is '{thread_count}' threads")
+def step_impl_closed_thread_count_validate(context, thread_count):
+    nose.tools.assert_equal(int(thread_count), context.bdd_helper.thread_counts_all_conversation_types['closed'])
+
+
+@then("the thread my_conversations count is '{thread_count}' threads")
+def step_impl_my_conversations_thread_count_validate(context, thread_count):
+    nose.tools.assert_equal(int(thread_count),
+                            context.bdd_helper.thread_counts_all_conversation_types['my_conversations'])
+
+
+@then("the thread new_respondent_conversations count is '{thread_count}' threads")
+def step_impl_new_respondent_conversations_thread_count_validate(context, thread_count):
+    nose.tools.assert_equal(int(thread_count),
+                            context.bdd_helper.thread_counts_all_conversation_types['new_respondent_conversations'])
 
 
 @given("debug step")

--- a/tests/behavioural/features/steps/endpoints.py
+++ b/tests/behavioural/features/steps/endpoints.py
@@ -319,6 +319,24 @@ def _step_impl_get_threads_count(context, args):
         context.bdd_helper.thread_count = -1
 
 
+def _step_impl_get_threads_count_for_all_conversation_types(context, args):
+    url = context.bdd_helper.threads_get_count_url + args
+    context.response = context.client.get(url, headers=context.bdd_helper.headers)
+    response_data = context.response.data
+    if context.response.status_code == 200:
+        context.bdd_helper.thread_counts_all_conversation_types = json.loads(response_data)["totals"]
+    else:
+        context.bdd_helper.thread_counts_all_conversation_types = None
+
+
 @then("A count of '{count}' is returned")
 def step_impl_the_return_count_is(context, count):
     nose.tools.assert_equal(count, context.bdd_helper.last_saved_message_data['msg_to'])
+
+
+@when("the count of all conversation types closed threads for current user is made")
+@given("the count of all conversation types closed threads for current user is made")
+def step_impl_all_conversation_types_count_are_counted(context):
+    """access the messages_count endpoint with all_conversation_types set"""
+    url_args = f"?all_conversation_types=true"
+    _step_impl_get_threads_count_for_all_conversation_types(context, url_args)

--- a/tests/behavioural/features/steps/secure_messaging_context_helper.py
+++ b/tests/behavioural/features/steps/secure_messaging_context_helper.py
@@ -74,6 +74,10 @@ class SecureMessagingContextHelper:
         self._messages_responses_data = []
         self._last_saved_message_data = None
         self._last_returned_thread_count = 0
+        self._last_returned_thread_counts_all_conversation_types = {'open': 0,
+                                                                    'closed': 0,
+                                                                    'my_conversations': 0,
+                                                                    'new_respondent_conversations': 0}
         self.additional_respondent_claims = {}
 
         # Urls
@@ -223,6 +227,14 @@ class SecureMessagingContextHelper:
     @thread_count.setter
     def thread_count(self, value):
         self._last_returned_thread_count = int(value)
+
+    @property
+    def thread_counts_all_conversation_types(self):
+        return self._last_returned_thread_counts_all_conversation_types
+
+    @thread_counts_all_conversation_types.setter
+    def thread_counts_all_conversation_types(self, value):
+        self._last_returned_thread_counts_all_conversation_types = value
 
     @property
     def sent_messages(self):

--- a/tests/behavioural/features/steps/status_code.py
+++ b/tests/behavioural/features/steps/status_code.py
@@ -8,6 +8,12 @@ def step_impl_200_success_returned(context):
     nose.tools.assert_equal(context.response.status_code, 200)
 
 
+@then('a success status code no content 204 is returned')
+def step_impl_204_success_returned(context):
+    """validate that the status code was 204"""
+    nose.tools.assert_equal(context.response.status_code, 204)
+
+
 @then('a created status code 201 is returned')
 def step_impl_201_success_returned(context):
     """validate that the status code was 201"""

--- a/tests/behavioural/features/steps/thread_state.py
+++ b/tests/behavioural/features/steps/thread_state.py
@@ -1,0 +1,12 @@
+from behave import given, when
+from flask import json
+
+
+@when("the last returned thread is closed")
+@given("the last returned thread is closed")
+def step_impl_the_response_message_thread_is_closed(context):
+    """close the conversation of the last saved message"""
+    thread_id = context.bdd_helper.single_message_responses_data[0]['thread_id']
+    url = context.bdd_helper.thread_get_url.format(thread_id)
+    context.response = context.client.patch(url, data=json.dumps({"is_closed": True}),
+                                            headers=context.bdd_helper.headers)

--- a/tests/behavioural/features/thread_patch.feature
+++ b/tests/behavioural/features/thread_patch.feature
@@ -1,0 +1,11 @@
+Feature: Threads patch endpoint
+
+  Background: Reset database
+    Given prepare for tests using 'mock' services
+
+Scenario: Respondent starts a conversation , some to group/user,  internal closes the conversation
+Given sending from respondent to internal group
+  And '1' messages are sent
+When the user is set as internal specific user
+  And the last returned thread is closed
+Then a success status code no content 204 is returned

--- a/tests/behavioural/features/threads_count.feature
+++ b/tests/behavioural/features/threads_count.feature
@@ -165,3 +165,34 @@ Scenario: Respondent sends messages to different ru, internal user filters by ru
   When  the user is set as internal specific user
     And the count of open threads for current user and business_id of 'additional_ru1' is made
   Then  the thread count is '2' threads
+
+Scenario: Internal user gets threads count with all_conversation_types when messages sent to a specific user
+   Given sending from respondent to internal specific user
+     And '7' messages are sent
+    When the user is set as internal specific user
+     And the count of all conversation types closed threads for current user is made
+    Then the thread open count is '7' threads
+     And the thread closed count is '0' threads
+     And the thread my_conversations count is '7' threads
+     And the thread new_respondent_conversations count is '0' threads
+
+Scenario: Internal user gets threads count with all_conversation_types when messages sent to a general user
+   Given sending from respondent to internal group
+     And '7' messages are sent
+    When the user is set as internal specific user
+     And the count of all conversation types closed threads for current user is made
+    Then the thread open count is '7' threads
+     And the thread closed count is '0' threads
+     And the thread my_conversations count is '0' threads
+     And the thread new_respondent_conversations count is '7' threads
+
+Scenario: Internal user gets threads count with all_conversation_types with a closed message and messages sent to GROUP
+   Given sending from respondent to internal group
+     And '7' messages are sent
+     And the user is set as internal specific user
+     And the last returned thread is closed
+    When the count of all conversation types closed threads for current user is made
+    Then the thread open count is '6' threads
+     And the thread closed count is '1' threads
+     And the thread my_conversations count is '0' threads
+     And the thread new_respondent_conversations count is '6' threads


### PR DESCRIPTION
**What is the context of this PR?**

https://trello.com/c/3Bj1gYTy
There is a need to display the counts of secure message conversations in the title of each tab .
This PR enables that through a call to Secure message. 
It adds support for all_conversation_type parameter in the Thread count end point. This returns counts for open,closed,new_respondent_conversations and my conversations all in one endpoint. Its not practical to fulifil this in a single database query, a single conversation can count in multiple classes, and the selection criteria are complex. This code submits 4 queries and amalgamates the data .  

**How to review**
Run tests. New tests added for the additional parameter.

