### PR TITLE
changed message body character limit to 50000

### DIFF
--- a/API.md
+++ b/API.md
@@ -47,7 +47,7 @@ See the endpoint descriptions for detailed usage of each field. This is an overv
 * From . (msg_from) This is the uuid of the actor that sent a message. If the actor is a respondent then it is their user uuid. If they are an internal user then it will be their user uuid.
 * To . (msg_to) These are the user uuids of the recipients of the message. Currently only one to user is supported. The message to can be as 'From' but with the addition that it can be the constant 'GROUP' to indicate that the message is being sent to a group handling the specific survey at the ons.
 * Subject . (subject) The subject of the message. Limited in the API to 100 characters , but since replies are prefixed with 'Re: ' then in practice it is 96 characters.
-* Body . (body) Up to 10000 characters.
+* Body . (body) Up to 50000 characters.
 * Survey . (survey). This is the uuid of the survey . It is mandatory when saving a message.
 * Collection Exercise .  (collection exercise) uuid of the collection exercise , can be used as a filter option (ce)
 * Reporting unit . (ru) uuid of the reporting unit . Can be used as a filter option.

--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.12
+appVersion: 2.0.13

--- a/migrations/003_increase_message_field_length_to_50000.sql
+++ b/migrations/003_increase_message_field_length_to_50000.sql
@@ -1,0 +1,1 @@
+ALTER TABLE securemessage.secure_message ALTER COLUMN body VARCHAR (50000);

--- a/secure_message/constants.py
+++ b/secure_message/constants.py
@@ -2,7 +2,7 @@
 
 MAX_TO_LEN = 100                  # Maximum size of a message TO field
 MAX_FROM_LEN = 100                # Maximum size of a From Field in a message
-MAX_BODY_LEN = 10000              # Maximum size if the Body field in a message
+MAX_BODY_LEN = 50000              # Maximum size of the Body field in a message
 MAX_SUBJECT_LEN = 100             # Maximum length of the subject field in a message
 MAX_THREAD_LEN = 60               # Maximum size of a thread_id UUID in a message
 MAX_MSG_ID_LEN = 60               # Maximum size of a message UUID in a message

--- a/tests/behavioural/features/thread_get.feature
+++ b/tests/behavioural/features/thread_get.feature
@@ -63,7 +63,7 @@ Feature: Get thread by id Endpoint
 
   Scenario Outline: Respondent sends a message to internal group, validate the entire message body is received
     Given sending from respondent to internal <user>
-      And   the message body is '10000' characters long
+      And   the message body is '50000' characters long
       And   the message is sent
     When the thread is read
     Then  a success status code 200 is returned


### PR DESCRIPTION
**What is the context of this PR?**

The message body character limit needed to be increased to 50,000.


**Changes**

- Changed character limit to 50000 and adjusted documentation accordingly.

**How to review**

Create a message of more than 10000 characters and ensure that the system allows it.

**Links**

[Jira card](https://collaborate2.ons.gov.uk/jira/browse/RAS-16)