### PR TITLE
updated readme about database migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,7 @@ Environment variables available for configuration are listed below:
 | CLIENT_SECRET                   | Password of the client service in UAA                         | N/A
 | UAA_URL                         | URL of a UAA instance                                         | N/A
 | USE_UAA                         | Sets whether a client token should be retrieved               | 1
+
+## Database migrations
+
+Although there exists a 'migrations' folder for SQL database migration files, this service does not currently use any database migration tools such as Alembic. As such, the migration files are simply there for record-keeping purposes. Migration scripts will need to be performed manually on the database.

--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.14
+appVersion: 2.0.15


### PR DESCRIPTION
**What is the context of this PR?**

Just a small addition to the readme about database migrations. I was looking around this service to see if we use any tools for database migration, but we don't, it seems. I originally thought this service might have used Flyway, but that's only usable with Java, not Python. I discussed this with Adam Mann and he said that previously, database migrations had always been executed manually on the database because that was easier than using tools.

**Changes**
- Updated `README.md`