### PR TITLE
Mark all messages in a conversation as read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,15 @@ lint:
 	pipenv run pylint --output-format=colorized -j 0 --reports=n ./secure_message
 	pipenv check ./secure_message ./tests
 
+unit-test:
+	export APP_SETTINGS=TestConfig && pipenv run pytest && unset APP_SETTINGS
+
 test: lint
 	pipenv run behave --format progress
 	export APP_SETTINGS=TestConfig && pipenv run pytest && unset APP_SETTINGS
+
+build-docker:
+	docker build .
+
+build-kubernetes:
+	docker build -f _infra/docker/Dockerfile .

--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.3
+appVersion: 2.1.4

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -82,8 +82,9 @@ class Modifier:
     def mark_message_as_read(message, user):
         """Remove unread label from status"""
         logger.debug("marking message as read with id", message=message['msg_id'])
+        # mark the message as read i.e. remove the unread label and set the `read at` time.
         Modifier._mark_read(message, user)
-        # also need to mark any other messages in the conversation as read
+        # also need to mark any other messages in the thread as read
         if message['thread_id']:
             try:
                 conversation = Retriever.retrieve_thread(message['thread_id'], user)

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -102,6 +102,7 @@ class Modifier:
     def _mark_read(message, user):
         inbox = Labels.INBOX.value
         unread = Labels.UNREAD.value
+        # message is unread if it has an UNREAD label and the `read_at` time isn't set
         if inbox in message['labels'] and unread in message['labels'] and 'read_date' not in message:
             # Save to both events and secure_message table for now.  In future, the save to the
             # events table will be removed.

--- a/tests/app/test_alerts.py
+++ b/tests/app/test_alerts.py
@@ -27,7 +27,7 @@ class AlertsTestCase(unittest.TestCase):
             "GOOGLE_CLOUD_PROJECT": "test",
             "PUBSUB_TOPIC": "testTopic"
         })
-        expectedPayload = json.dumps({"notify":{
+        expectedPayload = json.dumps({"notify": {
             "email_address": "test@email.com",
             "personalisation": self.personalisation,
             "reference": "myReference",

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -128,7 +128,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
         self.engine.dispose()
 
     def test_all_messages_in_conversation_marked_unread(self):
-        # create a thead with two messages
+        # create a thread with two messages
         conversation_id = self.create_conversation_with_respondent_as_unread(user=self.user_respondent, message_count=2)
         with self.app.app_context():
             conversation = Retriever.retrieve_thread(conversation_id, self.user_respondent)

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -133,7 +133,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
         with self.app.app_context():
             conversation = Retriever.retrieve_thread(conversation_id, self.user_respondent)
             for msg in conversation.all():
-                # as there's two indications that a message is unread, first check the read at isn't set
+                # as there's two ways that a message is unread, first check the `read at` time isn't set
                 self.assertIsNone(msg.read_at)
                 # now collect all the message labels
                 labels = []
@@ -145,9 +145,9 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             Modifier.mark_message_as_read(conversation[0].serialize(self.user_respondent), self.user_respondent)
             con = Retriever.retrieve_thread(conversation_id, self.user_respondent)
             for msg in con.all():
-                # message read should now be set
+                # message `read at` should now be set
                 self.assertIsNotNone(msg.read_at)
-                # collect the labels againg
+                # collect the labels again
                 labels = []
                 for status in msg.statuses:
                     labels.append(status.label)


### PR DESCRIPTION
If an internal users sends two messages to an external respondent then it was impossible to mark the first as read so the user would always have a notification for it.

This change marks all messages in the thread as read when the latest one is.

https://trello.com/c/4PRWzCg3/234-ritm0459542-respondent-has-notification-of-unread-message-but-when-they-look-in-open-and-closed-there-are-no-new-messages
