### PR TITLE
Only mark unread in certain scenarios

### DIFF
--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.32
+appVersion: 2.1.33

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -82,7 +82,7 @@ class ThreadById(Resource):
 
             # We only want to mark messages as unread if the most recent message was from a respondent.  Otherwise,
             # we're marking our own message as unread which is a bit pointless.
-            if not most_recent_message.from_internal:
+            if not most_recent_message['from_internal']:
                 if 'INBOX' in most_recent_message['labels']:
                     if 'UNREAD' not in most_recent_message['labels']:
                         Modifier.add_unread(most_recent_message, g.user)


### PR DESCRIPTION
# What and why?

There was an assumption made that the most recent message in thread would have an 'INBOX' label against it.  This is isn't always in the case (I think, in the case where an internal person has sent a message to a respondent, and then you get the threads messages as an internal user?).

This PR only marks a message as unread in response ops if the last message was from a respondent, and it has the inbox label.  We don't need to mark our own messages as unread as that's pointless.

# How to test?

# Trello
