### PR TITLE
Remove events table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ start:
 	pipenv run python run.py
 
 lint:
-	pipenv run flake8
 	pipenv check
 	pipenv run isort .
 	pipenv run black --line-length 120 .
+	pipenv run flake8
 
 lint-check:
-	pipenv run flake8
 	pipenv check
 	pipenv run isort --check-only .
 	pipenv run black --line-length 120 .
+	pipenv run flake8
 
 unit-test:
 	pipenv run pytest

--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.36
+version: 2.1.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.36
+appVersion: 2.1.37

--- a/migrations/006_remove_events_table.sql
+++ b/migrations/006_remove_events_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE securemessage.events;

--- a/secure_message/common/eventsapi.py
+++ b/secure_message/common/eventsapi.py
@@ -1,9 +1,0 @@
-from enum import Enum
-
-
-class EventsApi(Enum):
-    """Includes all event for the api"""
-
-    SENT = "Sent"
-    READ = "Read"
-    event_list = [SENT, READ]

--- a/secure_message/constants.py
+++ b/secure_message/constants.py
@@ -17,10 +17,6 @@ MAX_COLLECTION_EXERCISE_LEN = 60  # Maximum size of the message collection exerc
 MAX_STATUS_LABEL_LEN = 50  # Maximum length of a label column
 MAX_STATUS_ACTOR_LEN = 100  # Maximum length of the actor column
 
-# Events Table Column Size Definitions
-
-MAX_EVENT_LEN = 20  # Maximum length of a event column
-
 # Endpoint names
 
 MESSAGE_BY_ID_ENDPOINT = "message"

--- a/secure_message/repository/database.py
+++ b/secure_message/repository/database.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import (
@@ -43,7 +43,6 @@ class SecureMessage(db.Model):
     read_at = Column("read_at", DateTime())
 
     statuses = relationship("Status", backref="secure_message", lazy="dynamic")
-    events = relationship("Events", backref="secure_message", order_by="Events.date_time", lazy="dynamic")
 
     __table_args__ = (Index("idx_ru_survey_cc", "business_id", "survey_id", "case_id", "exercise_id"),)
 
@@ -178,26 +177,6 @@ class Status(db.Model):
         data = {"msg_id": self.msg_id, "actor": self.actor, "label": self.label}
 
         return data
-
-
-class Events(db.Model):
-    """Events table model"""
-
-    __tablename__ = "events"
-
-    id = Column("id", Integer(), primary_key=True)
-    event = Column("event", String(constants.MAX_EVENT_LEN + 1))
-    msg_id = Column("msg_id", String(constants.MAX_MSG_ID_LEN + 1), ForeignKey("secure_message.msg_id"), index=True)
-    date_time = Column("date_time", DateTime())
-    __table_args__ = (Index("idx_msg_id_event", "msg_id", "event"),)
-
-    def __init__(self, msg_id="", event=""):
-        self.msg_id = msg_id
-        self.event = event
-        self.date_time = datetime.now(timezone.utc)
-
-    def __repr__(self):
-        return f"<Events(msg_id={self.msg_id} event={self.event}, date_time={self.date_time}"
 
 
 class Conversation(db.Model):

--- a/secure_message/repository/database.py
+++ b/secure_message/repository/database.py
@@ -16,7 +16,6 @@ from sqlalchemy.orm import relationship
 from structlog import wrap_logger
 
 from secure_message import constants
-from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -108,6 +107,8 @@ class SecureMessage(db.Model):
             "survey_id": self.survey_id,
             "exercise_id": self.exercise_id,
             "from_internal": self.from_internal,
+            "sent_date": self.sent_at,
+            "read_date": self.read_at,
             "_links": "",
             "labels": [],
         }
@@ -116,8 +117,6 @@ class SecureMessage(db.Model):
             self._populate_to_from_and_labels_internal_user(message)
         else:
             self._populate_to_from_and_labels_respondent(user, message)
-
-        self._populate_events(message)
 
         return message
 
@@ -150,13 +149,6 @@ class SecureMessage(db.Model):
             message["msg_to"].append(row.actor)
         elif row.label == Labels.SENT.value:
             message["msg_from"] = row.actor
-
-    def _populate_events(self, message):
-        for row in self.events:
-            if row.event == EventsApi.SENT.value:
-                message["sent_date"] = str(row.date_time)
-            elif row.event == EventsApi.READ.value:
-                message["read_date"] = str(row.date_time)
 
 
 class Status(db.Model):

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -7,17 +7,10 @@ from sqlalchemy.orm.exc import NoResultFound
 from structlog import wrap_logger
 from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 
-from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
 from secure_message.common.utilities import set_conversation_type_args
 from secure_message.constants import NON_SPECIFIC_INTERNAL_USER
-from secure_message.repository.database import (
-    Conversation,
-    Events,
-    SecureMessage,
-    Status,
-    db,
-)
+from secure_message.repository.database import Conversation, SecureMessage, Status, db
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -300,8 +293,7 @@ class Retriever:
 
         try:
             result = (
-                SecureMessage.query.join(Events)
-                .join(Status)
+                SecureMessage.query.join(Status)
                 .filter(SecureMessage.thread_id == thread_id)
                 .filter(
                     or_(
@@ -309,7 +301,6 @@ class Retriever:
                         and_(SecureMessage.from_internal.is_(True), Status.label.in_([Labels.SENT.value])),
                     )
                 )
-                .filter(Events.event == EventsApi.SENT.value)
                 .order_by(Status.id.desc())
             )
 

--- a/secure_message/repository/saver.py
+++ b/secure_message/repository/saver.py
@@ -4,13 +4,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from structlog import wrap_logger
 
 from secure_message.exception.exceptions import MessageSaveException
-from secure_message.repository.database import (
-    Conversation,
-    Events,
-    SecureMessage,
-    Status,
-    db,
-)
+from secure_message.repository.database import Conversation, SecureMessage, Status, db
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -58,17 +52,4 @@ class Saver:
         except SQLAlchemyError:
             session.rollback()
             logger.exception("Message status save failed")
-            raise MessageSaveException("Message save failed")
-
-    @staticmethod
-    def save_msg_event(msg_id, event, session=db.session):
-        """save message events to events database"""
-        event = Events(msg_id=msg_id, event=event)
-
-        try:
-            session.add(event)
-            session.commit()
-        except SQLAlchemyError:
-            session.rollback()
-            logger.exception("Message event save failed")
             raise MessageSaveException("Message save failed")

--- a/secure_message/resources/messages.py
+++ b/secure_message/resources/messages.py
@@ -8,7 +8,6 @@ from werkzeug.exceptions import BadRequest
 
 from secure_message import constants
 from secure_message.common.alerts import AlertViaGovNotify, AlertViaLogging
-from secure_message.common.eventsapi import EventsApi
 from secure_message.common.labels import Labels
 from secure_message.repository.database import SecureMessage
 from secure_message.repository.modifier import Modifier
@@ -61,8 +60,6 @@ class MessageSend(Resource):
     def _message_save(message: Message):
         """Saves the message to the database along with the subsequent status and audit"""
         Saver.save_message(message)
-        Saver.save_msg_event(message.msg_id, EventsApi.SENT.value)
-
         Saver.save_msg_status(message.msg_from, message.msg_id, Labels.SENT.value)
         Saver.save_msg_status(message.msg_to[0], message.msg_id, Labels.INBOX.value)
         Saver.save_msg_status(message.msg_to[0], message.msg_id, Labels.UNREAD.value)

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -211,8 +211,8 @@ class AppTestCase(unittest.TestCase):
             for row in db_data:
                 self.assertTrue(row is not None)
 
-    def test_message_post_stores_events_correctly_for_message(self):
-        """posts to message send end point to ensure events are saved as expected"""
+    def test_message_post_stores_sent_at_correctly_for_message(self):
+        """posts to message send end point to ensure sent_at is saved as expected"""
         url = "http://localhost:5050/messages"
 
         response = self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 from unittest.mock import patch
 
@@ -218,11 +219,10 @@ class AppTestCase(unittest.TestCase):
         data = json.loads(response.data)
 
         with self.engine.connect() as con:
-            db_data = con.execute(
-                f"SELECT * FROM securemessage.events WHERE event='Sent' AND msg_id='{data['msg_id']}'"
-            )
+            db_data = con.execute(f"SELECT * FROM securemessage.secure_message where msg_id='{data['msg_id']}'")
             for row in db_data:
                 self.assertTrue(row is not None)
+                self.assertTrue(isinstance(row["sent_at"], datetime.datetime))
 
     def test_message_post_stores_labels_correctly_for_recipient_of_message(self):
         """posts to message send end point to ensure labels are saved as expected"""

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -7,7 +7,6 @@ from sqlalchemy import create_engine
 from werkzeug.exceptions import Forbidden, NotFound
 
 from secure_message.application import create_app
-from secure_message.common.eventsapi import EventsApi
 from secure_message.common.utilities import MessageArgs
 from secure_message.constants import MESSAGE_QUERY_LIMIT
 from secure_message.repository import database
@@ -38,17 +37,30 @@ class RetrieverTestCaseHelper:
         survey_id=BRES_SURVEY,
         exercise_id="CollectionExercise",
         from_internal=False,
+        sent_at=datetime.utcnow(),
+        include_read_at=False,
     ):
 
         """Populate the secure_message table"""
 
         with self.engine.connect() as con:
-            query = (
-                f"INSERT INTO securemessage.secure_message(msg_id, subject, body, thread_id,"
-                f"case_id, business_id, survey_id, exercise_id, from_internal)"
-                f"VALUES ('{msg_id}', '{subject}','{body}',"
-                f"'{thread_id}', '{case_id}', '{business_id}', '{survey_id}', '{exercise_id}', '{from_internal}')"
-            )
+            if include_read_at:
+                read_at = datetime.utcnow()
+                query = (
+                    f"INSERT INTO securemessage.secure_message(msg_id, subject, body, thread_id,"
+                    f"case_id, business_id, survey_id, exercise_id, from_internal, sent_at, read_at)"
+                    f"VALUES ('{msg_id}', '{subject}','{body}',"
+                    f"'{thread_id}', '{case_id}', '{business_id}', '{survey_id}',"
+                    f" '{exercise_id}', '{from_internal}',  '{sent_at}', '{read_at}')"
+                )
+            else:
+                query = (
+                    f"INSERT INTO securemessage.secure_message(msg_id, subject, body, thread_id,"
+                    f"case_id, business_id, survey_id, exercise_id, from_internal, sent_at)"
+                    f"VALUES ('{msg_id}', '{subject}','{body}',"
+                    f"'{thread_id}', '{case_id}', '{business_id}', '{survey_id}',"
+                    f" '{exercise_id}', '{from_internal}',  '{sent_at}')"
+                )
             con.execute(query)
 
     def add_conversation(self, conversation_id, is_closed=False, category="SURVEY"):
@@ -84,28 +96,36 @@ class RetrieverTestCaseHelper:
         external_actor=default_external_actor,
         internal_actor=default_internal_actor,
         category="SURVEY",
+        include_read_at=False,
     ):
         """Populate the db with a thread with a specified number of messages"""
 
         msg_id = str(uuid.uuid4())
         thread_id = msg_id
         self.add_conversation(conversation_id=thread_id, category=category)
-        self.add_secure_message(msg_id=msg_id, thread_id=thread_id, survey_id=self.BRES_SURVEY, from_internal=False)
+        self.add_secure_message(
+            msg_id=msg_id,
+            thread_id=thread_id,
+            survey_id=self.BRES_SURVEY,
+            from_internal=False,
+            include_read_at=include_read_at,
+        )
         self.add_status(label="SENT", msg_id=msg_id, actor=external_actor)
         self.add_status(label="INBOX", msg_id=msg_id, actor=internal_actor)
-        self.add_event(event=EventsApi.SENT.value, msg_id=msg_id, date_time=datetime.utcnow())
-        self.add_event(event=EventsApi.READ.value, msg_id=msg_id, date_time=datetime.utcnow())
 
         if no_of_messages > 1:
             for _ in range(no_of_messages - 1):
                 msg_id = str(uuid.uuid4())
                 self.add_secure_message(
-                    msg_id=msg_id, thread_id=thread_id, survey_id=self.BRES_SURVEY, from_internal=True
+                    msg_id=msg_id,
+                    thread_id=thread_id,
+                    survey_id=self.BRES_SURVEY,
+                    from_internal=True,
+                    include_read_at=include_read_at,
                 )
                 self.add_status(label="SENT", msg_id=msg_id, actor=internal_actor)
                 self.add_status(label="UNREAD", msg_id=msg_id, actor=external_actor)
                 self.add_status(label="INBOX", msg_id=msg_id, actor=external_actor)
-                self.add_event(event=EventsApi.SENT.value, msg_id=msg_id, date_time=datetime.utcnow())
 
         return thread_id
 
@@ -209,14 +229,9 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
     def test_read_date_returned_for_message(self):
         """retrieves message using id and checks the read date returned"""
-        self.create_thread(no_of_messages=2)
+        self.create_thread(no_of_messages=2, include_read_at=True)
         with self.engine.connect() as con:
-            query_sql = (
-                "SELECT securemessage.secure_message.msg_id FROM securemessage.secure_message "
-                "JOIN securemessage.events ON securemessage.secure_message.msg_id = securemessage.events.msg_id "
-                "WHERE securemessage.events.event = '" + EventsApi.READ.value + "' LIMIT 1"
-            )
-            query = con.execute(query_sql)
+            query = con.execute("SELECT msg_id FROM securemessage.secure_message LIMIT 1")
             msg_id = query.first()[0]
             with self.app.app_context():
                 with current_app.test_request_context():
@@ -242,7 +257,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
                 response = Retriever.retrieve_thread(thread_id, self.user_respondent)
                 self.assertEqual(len(response.all()), 6)
 
-                sent = [str(message.events[0].date_time) for message in response.all()]
+                sent = [str(message.sent_at) for message in response.all()]
 
                 desc_date = sorted(sent, reverse=True)
                 self.assertEqual(len(sent), 6)
@@ -348,12 +363,11 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
                 self.assertEqual(len(msg_ids), 5)
 
-                args = get_args(page=1, limit=MESSAGE_QUERY_LIMIT)
-
                 for x in range(0, len(thread_ids)):
                     thread = Retriever.retrieve_thread(thread_ids[x], self.user_internal)
-                    self.assertEqual(date[x], str(thread.all()[0].events[0].date_time))
-                    self.assertEqual(msg_ids[x], thread.all()[0].events[0].msg_id)
+                    first_msg_in_thread = thread.all()[0]
+                    self.assertEqual(date[x], first_msg_in_thread.sent_at)
+                    self.assertEqual(msg_ids[x], first_msg_in_thread.msg_id)
 
     def test_thread_count_by_survey_my_conversations_off(self):
         """checks that the returned thread count is the same for every internal user

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -80,16 +80,6 @@ class RetrieverTestCaseHelper:
             query = f"INSERT INTO securemessage.status(label, msg_id, actor) VALUES('{label}', '{msg_id}', '{actor}')"
             con.execute(query)
 
-    def add_event(self, event, msg_id, date_time):
-        """Populate the event table"""
-
-        with self.engine.connect() as con:
-            query = (
-                f"INSERT INTO securemessage.events(event, msg_id, date_time)"
-                f" VALUES('{event}', '{msg_id}', '{date_time}')"
-            )
-            con.execute(query)
-
     def create_thread(
         self,
         no_of_messages=1,
@@ -226,6 +216,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
                     response = Retriever.retrieve_message(msg_id, self.user_internal)
                     self.assertTrue("modified_date" not in response)
                     self.assertTrue(response["sent_date"] != "N/A")
+            con.close()
 
     def test_read_date_returned_for_message(self):
         """retrieves message using id and checks the read date returned"""
@@ -238,6 +229,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
                     response = Retriever.retrieve_message(msg_id, self.user_internal)
                     self.assertTrue("modified_date" not in response)
                     self.assertTrue(response["read_date"] != "N/A")
+            con.close()
 
     def test_all_msg_returned_for_thread_id(self):
         """retrieves messages for thread_id from database"""

--- a/tests/app/test_saver.py
+++ b/tests/app/test_saver.py
@@ -92,7 +92,7 @@ class SaverTestCase(unittest.TestCase):
                 with self.assertRaises(MessageSaveException):
                     Saver().save_msg_status(message_status["actor"], message_status["msg_id"], "INBOX", mock_session)
 
-    def test_saved_msg_event_has_been_saved(self):
+    def test_saved_msg_id_and_sent_at_has_been_saved(self):
         """retrieves message event from database"""
         with self.app.app_context():
             with current_app.test_request_context():
@@ -102,11 +102,12 @@ class SaverTestCase(unittest.TestCase):
             request = con.execute("SELECT * FROM securemessage.secure_message limit 1")
             for row in request:
                 self.assertTrue(row is not None)
-                self.assertTrue(row[1] == "AMsgId")
+                self.assertTrue(row["msg_id"] == "AMsgId")
 
                 # Just check that sent_at (11th element) is set without checking the value as we don't have it
-                self.assertIsInstance(row[10], datetime.datetime)
-                self.assertTrue(row[10] is not None)
+                self.assertIsInstance(row["sent_at"], datetime.datetime)
+                self.assertTrue(row["sent_at"] is not None)
+            con.close()
 
     def test_status_commit_exception_raises_message_save_exception(self):
         """check status commit exception clears the session"""


### PR DESCRIPTION
# What and why?

The event table hasn't been needed for a while.  The info it stores is also stored against each message (as `sent_at` and `read_at`).  This PR removes all mention of it and updates the few places it was used to use the new columns.  This should simplify the design of this service greatly.

# How to test?

- Run acceptance tests in dev environment
- Create 2 more threads (internal to external, and the reverse)
- Deploy app to your environment
- Test it manually (check threads on both internal and external look as expected)
- After testing to make sure it works, delete the events table (with supplied script in PR).  Make sure it still works (manually and/or with acceptance tests)

Through my testing I saw that it worked just fine regardless of what state the database was in as long as the schema (and whatever tables) had been created.

# Trello
