### PR TITLE
Return default user details when internal users not found

### DIFF
--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.46
+version: 2.1.47
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.46
+appVersion: 2.1.47

--- a/secure_message/services/internal_user_service.py
+++ b/secure_message/services/internal_user_service.py
@@ -32,10 +32,12 @@ class InternalUserService:
             resp_json = response.json()
         except HTTPError:
             logger.exception("Failed to get user info", uuid=uuid)
-            raise
+            user_details = InternalUserService.get_default_user_details(uuid)
+            return user_details
         except ValueError:
             logger.exception("Failed to decode response JSON", uuid=uuid)
-            raise
+            user_details = InternalUserService.get_default_user_details(uuid)
+            return user_details
 
         try:
             user_details = {


### PR DESCRIPTION
# What and why?
If an internal user has been deleted, any thread that comes from that user will generic 500 as the 404 from UAA isn't handled properly. This fixes it by just returning the default "ONS User" text that we already return if we end up with only partial information from UAA.

# How to test?

- Make a thread between an internal and external user
- Delete the internal user
- Check your message thread as an internal user; it shouldn't throw a 500 and should appear as being from "ONS User"

# Trello
https://trello.com/c/GOu2O5zI/1937-bug-handle-missing-internal-users-properly-in-secure-message-15m