### PR TITLE
Update publish chart dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'
         run: |
-          cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tg
+          cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - uses: actions/create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Publish dev Chart
         if: github.ref != 'refs/heads/main'
         run: |
-          mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
+          mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ steps.tag.outputs.pr_number }}.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Build Release Image
@@ -173,6 +173,7 @@ jobs:
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'
         run: |
+          cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tg
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - uses: actions/create-release@v1

--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.49
+version: 2.1.50
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.49
+appVersion: 2.1.50


### PR DESCRIPTION
# What and why?
Currently on a push to a PR each repo builds to latest in onsrasrm-management, however this is the default artifact for all builds when using spinnaker. This means if any change to the charts are made and a PR is created it can and will break dev for everyone. 

# How to test?
Check the build (Publish dev Chart) and make sure it is writing naming the artifact correctly, it should be xx-pr-xx.tgz. You can also check on GCP in ons-rasrmbs-management that the artifact was written out at the right time