### PR TITLE
added index for conversation category

### DIFF
--- a/secure_message/repository/database.py
+++ b/secure_message/repository/database.py
@@ -188,7 +188,7 @@ class Conversation(db.Model):
     closed_by = Column("closed_by", String())
     closed_by_uuid = Column("closed_by_uuid", String(length=60))
     closed_at = Column("closed_at", DateTime())
-    category = Column("category", String(length=60), server_default="SURVEY")
+    category = Column("category", String(length=60), server_default="SURVEY", index=True)
 
     def __init__(self, is_closed=False, closed_by=None, closed_by_uuid=None, closed_at=None, category=None):
         self.is_closed = is_closed


### PR DESCRIPTION
# What and why?
I came up with a hypothesis that the reason why technical messages take so long to retrieve on preprod is because of a lack of indexing on the category column. This PR is to test that.

# How to test?
Deploy, run acceptance tests, and check the database to ensure that the category column in the conversation table has an index created for it.

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-784)
