### PR TITLE
database error handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - run: |
           gcloud auth configure-docker
 
@@ -176,18 +176,11 @@ jobs:
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
-      - uses: actions/create-release@v1
+      - name: Publish Release
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.version }}
-          release_name: ${{ env.version }}
-          body: |
-            Automated release
-            ${{ env.version }}
-          draft: false
-          prerelease: false
+        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.64
+version: 2.1.65
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.64
+appVersion: 2.1.65

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -41,6 +41,16 @@ class Modifier:
             session.add(status)
             session.commit()
             return True
+        except SQLAlchemyError as e:
+            session.rollback()
+            logger.error(
+                "Database error while adding label to status table",
+                msg_id=message["msg_id"],
+                label=label,
+                user_id=actor,
+                error=e.__class__.__name__,
+            )
+            raise
         except Exception as e:
             session.rollback()
             logger.error("Error adding label to database", msg_id=message, label=label, user_uuid=actor, error=e)
@@ -153,7 +163,7 @@ class Modifier:
         except SQLAlchemyError:
             db.session.rollback()
             bound_logger.exception("Database error occurred while opening conversation")
-            raise InternalServerError(description="Database error occurred while opening conversation")
+            raise
 
     @staticmethod
     def patch_message(request_data: dict, message: SecureMessage):
@@ -177,7 +187,7 @@ class Modifier:
         except SQLAlchemyError:
             db.session.rollback()
             bound_logger.exception("Database error occurred while patching message")
-            raise InternalServerError(description="Database error occurred while patching message")
+            raise
 
     @staticmethod
     def close_conversation(metadata: Conversation, user):
@@ -197,7 +207,7 @@ class Modifier:
         except SQLAlchemyError:
             db.session.rollback()
             bound_logger.exception("Database error occurred while closing conversation")
-            raise InternalServerError(description="Database error occurred while closing conversation")
+            raise
 
         bound_logger.info("Successfully closed conversation")
         bound_logger.unbind("conversation_id", "user_id")
@@ -216,7 +226,7 @@ class Modifier:
         except SQLAlchemyError:
             db.session.rollback()
             bound_logger.exception("Database error occured while opening conversation")
-            raise InternalServerError(description="Database error occured while opening conversation")
+            raise
 
         bound_logger.info("Successfully re-opened conversation")
         bound_logger.unbind("conversation_id", "user_id")

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -121,7 +121,7 @@ class Modifier:
         except SQLAlchemyError:
             db.session.rollback()
             logger.exception("Error marking thread as read", thread_id=thread_id)
-            raise InternalServerError(description="Error marking thread as read")
+            raise
 
     @staticmethod
     def _mark_read(message, user):
@@ -137,7 +137,7 @@ class Modifier:
             except SQLAlchemyError:
                 db.session.rollback()
                 logger.exception("Error adding read information to message", msg_id=message["msg_id"])
-                raise InternalServerError(description="Error adding read information to message")
+                raise
         Modifier.remove_label(unread, message, user)
 
     @staticmethod
@@ -184,7 +184,8 @@ class Modifier:
                         setattr(message, key, request_data[key])
 
             db.session.commit()
-        except SQLAlchemyError:
+        except SQLAlchemyError as e:
+            print(e)
             db.session.rollback()
             bound_logger.exception("Database error occurred while patching message")
             raise

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -14,6 +14,8 @@ from secure_message.repository.database import Conversation, SecureMessage, Stat
 
 logger = wrap_logger(logging.getLogger(__name__))
 
+THREAD_COUNT_ERROR = "Error retrieving count of threads by survey from database"
+
 
 class Retriever:
     """Created when retrieving messages"""
@@ -30,9 +32,12 @@ class Retriever:
                 .filter(Status.label == "UNREAD")
                 .count()
             )
+        except SQLAlchemyError as e:
+            logger.error(THREAD_COUNT_ERROR, error=e)
+            raise
         except Exception:
-            logger.exception("Error retrieving count of unread messages from database")
-            raise InternalServerError(description="Error retrieving count of unread messages from database")
+            logger.exception(THREAD_COUNT_ERROR)
+            raise InternalServerError(description=THREAD_COUNT_ERROR)
         return result
 
     @staticmethod
@@ -79,8 +84,11 @@ class Retriever:
 
             result = SecureMessage.query.filter(and_(*conditions)).distinct(SecureMessage.msg_id).count()
 
+        except SQLAlchemyError as e:
+            logger.error(THREAD_COUNT_ERROR, error=e)
+            raise
         except Exception as e:
-            logger.error("Error retrieving count of threads by survey from database", error=e)
+            logger.error(THREAD_COUNT_ERROR, error=e)
             raise InternalServerError(description="Error retrieving count of threads from database")
         return result
 
@@ -283,7 +291,7 @@ class Retriever:
 
         except SQLAlchemyError:
             logger.exception("Error retrieving conversation from database")
-            raise InternalServerError(description="Error retrieving conversation from database")
+            raise
 
         return result
 
@@ -310,7 +318,7 @@ class Retriever:
 
         except SQLAlchemyError:
             logger.exception("Error retrieving conversation from database", thread_id=thread_id)
-            raise InternalServerError(description=f"Error retrieving conversation '{thread_id}' from database")
+            raise
 
         return result
 

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -14,8 +14,6 @@ from secure_message.repository.database import Conversation, SecureMessage, Stat
 
 logger = wrap_logger(logging.getLogger(__name__))
 
-THREAD_COUNT_ERROR = "Error retrieving count of threads by survey from database"
-
 
 class Retriever:
     """Created when retrieving messages"""

--- a/secure_message/repository/retriever.py
+++ b/secure_message/repository/retriever.py
@@ -33,11 +33,11 @@ class Retriever:
                 .count()
             )
         except SQLAlchemyError as e:
-            logger.error(THREAD_COUNT_ERROR, error=e)
+            logger.error("Database error when getting unread message count", error=e)
             raise
         except Exception:
-            logger.exception(THREAD_COUNT_ERROR)
-            raise InternalServerError(description=THREAD_COUNT_ERROR)
+            logger.exception("Unknown error when getting unread message count")
+            raise InternalServerError(description="Unknown error when getting unread message count")
         return result
 
     @staticmethod
@@ -85,11 +85,11 @@ class Retriever:
             result = SecureMessage.query.filter(and_(*conditions)).distinct(SecureMessage.msg_id).count()
 
         except SQLAlchemyError as e:
-            logger.error(THREAD_COUNT_ERROR, error=e)
+            logger.error("Database error when getting thread count by survey", error=e)
             raise
         except Exception as e:
-            logger.error(THREAD_COUNT_ERROR, error=e)
-            raise InternalServerError(description="Error retrieving count of threads from database")
+            logger.error("Unknown error when getting thread count by survey", error=e)
+            raise InternalServerError(description="Unknown error when getting thread count by survey")
         return result
 
     @staticmethod
@@ -161,8 +161,8 @@ class Retriever:
             )
 
         except SQLAlchemyError:
-            logger.exception("Error retrieving messages from database")
-            raise InternalServerError(description="Error retrieving messages from database")
+            logger.exception("Database error when retrieving respondent thread list")
+            raise
 
         return result
 
@@ -219,8 +219,8 @@ class Retriever:
             )
 
         except SQLAlchemyError:
-            logger.exception("Error retrieving messages from database")
-            raise InternalServerError(description="Error retrieving messages from database")
+            logger.exception("Database error when retrieving internal thread list")
+            raise
 
         return result
 
@@ -293,7 +293,7 @@ class Retriever:
                 )
 
         except SQLAlchemyError:
-            logger.exception("Error retrieving conversation from database")
+            logger.exception("Database error when retrieving respondent conversation from database")
             raise
 
         return result.all()
@@ -320,7 +320,9 @@ class Retriever:
                 raise NotFound(description=f"Conversation with thread_id {thread_id} not retrieved")
 
         except SQLAlchemyError:
-            logger.exception("Error retrieving conversation from database", thread_id=thread_id)
+            logger.exception(
+                "Database error when retrieving respondent conversation from database", thread_id=thread_id
+            )
             raise
 
         return result

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -19,8 +19,6 @@ from secure_message.validation.thread import ThreadPatch
 
 logger = wrap_logger(logging.getLogger(__name__))
 
-THREAD_SERVICE_ERROR = "Thread service error"
-
 
 class ThreadById(Resource):
     """Return list of messages in a thread for user"""

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -1,8 +1,9 @@
 import logging
 
-from flask import abort, g, jsonify, request
+from flask import abort, g, jsonify, make_response, request
 from flask_restful import Resource
 from marshmallow import ValidationError
+from sqlalchemy.exc import SQLAlchemyError
 from structlog import wrap_logger
 from werkzeug.exceptions import BadRequest
 
@@ -18,6 +19,8 @@ from secure_message.validation.thread import ThreadPatch
 
 logger = wrap_logger(logging.getLogger(__name__))
 
+THREAD_SERVICE_ERROR = "Thread service error"
+
 
 class ThreadById(Resource):
     """Return list of messages in a thread for user"""
@@ -27,8 +30,13 @@ class ThreadById(Resource):
         """Get messages by thread id"""
         logger.info("Getting messages from thread", thread_id=thread_id, user_uuid=g.user.user_uuid)
 
-        conversation = Retriever.retrieve_thread(thread_id, g.user)
-        conversation_metadata = Retriever.retrieve_conversation_metadata(thread_id)
+        try:
+            conversation = Retriever.retrieve_thread(thread_id, g.user)
+            conversation_metadata = Retriever.retrieve_conversation_metadata(thread_id)
+        except SQLAlchemyError:
+            return make_response(
+                jsonify({"message": "Database error while retrieving message thread", "thread_id": thread_id}), 500
+            )
 
         logger.info("Successfully retrieved messages from thread", thread_id=thread_id, user_uuid=g.user.user_uuid)
         messages = []
@@ -70,29 +78,32 @@ class ThreadById(Resource):
         ThreadById._validate_patch_request(request_data, conversation)
 
         bound_logger.info("Attempting to modify metadata for thread")
-        Modifier.patch_conversation(request_data, conversation)
+        try:
+            Modifier.patch_conversation(request_data, conversation)
 
-        if request_data.get("is_closed") is not None:
-            if request_data.get("is_closed"):
-                bound_logger.info("About to close conversation")
-                Modifier.close_conversation(conversation, g.user)
-            else:
-                bound_logger.info("About to re-open conversation")
-                Modifier.open_conversation(conversation, g.user)
-        else:  # If anything changes in a thread that isn't is_closed, mark as unread
-            bound_logger.info("Marking thread as unread after thread data change")
-            full_conversation = Retriever.retrieve_thread(thread_id, g.user)
+            if request_data.get("is_closed") is not None:
+                if request_data.get("is_closed"):
+                    bound_logger.info("About to close conversation")
+                    Modifier.close_conversation(conversation, g.user)
+                else:
+                    bound_logger.info("About to re-open conversation")
+                    Modifier.open_conversation(conversation, g.user)
+            else:  # If anything changes in a thread that isn't is_closed, mark as unread
+                bound_logger.info("Marking thread as unread after thread data change")
+                full_conversation = Retriever.retrieve_thread(thread_id, g.user)
 
-            # First message in the list is always the most recent due to retrieve_thread ordering by id
-            most_recent_message = full_conversation[0].serialize(g.user)
+                # First message in the list is always the most recent due to retrieve_thread ordering by id
+                most_recent_message = full_conversation[0].serialize(g.user)
 
-            # We only want to mark messages as unread if the most recent message was from a respondent.  Otherwise,
-            # we're marking our own message as unread which is a bit pointless.
-            if not most_recent_message["from_internal"]:
-                if "INBOX" in most_recent_message["labels"]:
-                    if "UNREAD" not in most_recent_message["labels"]:
-                        Modifier.add_unread(most_recent_message, g.user)
-                        Modifier.patch_message({"read_at": None}, full_conversation[0])
+                # We only want to mark messages as unread if the most recent message was from a respondent.  Otherwise,
+                # we're marking our own message as unread which is a bit pointless.
+                if not most_recent_message["from_internal"]:
+                    if "INBOX" in most_recent_message["labels"]:
+                        if "UNREAD" not in most_recent_message["labels"]:
+                            Modifier.add_unread(most_recent_message, g.user)
+                            Modifier.patch_message({"read_at": None}, full_conversation[0])
+        except SQLAlchemyError as e:
+            return make_response(jsonify({"title": THREAD_SERVICE_ERROR, "detail": e.__class__.__name__}), 500)
 
         bound_logger.info("Thread metadata update successful")
         bound_logger.unbind("thread_id", "user_uuid")
@@ -137,7 +148,10 @@ class ThreadList(Resource):
 
         ThreadList._validate_request(message_args, g.user)
 
-        result = Retriever.retrieve_thread_list(g.user, message_args)
+        try:
+            result = Retriever.retrieve_thread_list(g.user, message_args)
+        except SQLAlchemyError as e:
+            return make_response(jsonify({"title": THREAD_SERVICE_ERROR, "detail": e.__class__.__name__}), 500)
 
         logger.info("Successfully retrieved threads for user", user_uuid=g.user.user_uuid)
         messages, links = process_paginated_list(result, request.host_url, g.user, message_args, THREAD_LIST_ENDPOINT)
@@ -168,12 +182,15 @@ class ThreadCounter(Resource):
         logger.info("Getting count of threads for user", user_uuid=g.user.user_uuid)
         message_args = get_options(request.args)
 
-        if message_args.all_conversation_types:
-            logger.info("Getting counts for all conversation states for user", user_uuid=g.user.user_uuid)
-            return jsonify(totals=Retriever.thread_count_by_survey_and_conversation_states(message_args, g.user))
+        try:
+            if message_args.all_conversation_types:
+                logger.info("Getting counts for all conversation states for user", user_uuid=g.user.user_uuid)
+                return jsonify(totals=Retriever.thread_count_by_survey_and_conversation_states(message_args, g.user))
 
-        if message_args.unread_conversations:
-            logger.info("Getting counts of unread conversations", user_uuid=g.user.user_uuid)
-            return jsonify(total=Retriever.unread_message_count(g.user))
+            if message_args.unread_conversations:
+                logger.info("Getting counts of unread conversations", user_uuid=g.user.user_uuid)
+                return jsonify(total=Retriever.unread_message_count(g.user))
 
-        return jsonify(total=Retriever.thread_count_by_survey(message_args, g.user))
+            return jsonify(total=Retriever.thread_count_by_survey(message_args, g.user))
+        except SQLAlchemyError as e:
+            return make_response(jsonify({"title": THREAD_SERVICE_ERROR, "detail": e.__class__.__name__}), 500)

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -129,11 +129,10 @@ class AppTestCase(unittest.TestCase):
         url = "http://localhost:5050/threads/f1a5e99c-8edf-489a-9c72-6cabe6c387fc"
         response = self.client.patch(url, data=json.dumps({"is_closed": True}), headers=self.external_user_header)
         self.assertEqual(response.status_code, 403)
-        error_message = (
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server."
+        self.assertEqual(
+            json.loads(response.get_data()),
+            {"message": "Thread modification is forbidden", "title": "Thread service error"},
         )
-        self.assertEqual(json.loads(response.get_data()), {"message": error_message})
 
     def test_reply_to_existing_message_has_same_thread_id_and_different_message_id_as_original(self):
         """check a reply gets same thread id as original"""

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -131,7 +131,7 @@ class AppTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
             json.loads(response.get_data()),
-            {"message": "Thread modification is forbidden", "title": "Thread service error"},
+            {"message": "Thread modification is forbidden", "title": "Error when modifying thread"},
         )
 
     def test_reply_to_existing_message_has_same_thread_id_and_different_message_id_as_original(self):

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -161,7 +161,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
         conversation_id = self.create_conversation_with_respondent_as_unread(user=self.user_respondent, message_count=2)
         with self.app.app_context():
             conversation = Retriever.retrieve_thread(conversation_id, self.user_respondent)
-            for msg in conversation.all():
+            for msg in conversation:
                 # as there's two ways that a message is unread, first check the `read at` time isn't set
                 self.assertIsNone(msg.read_at)
                 # now collect all the message labels
@@ -173,7 +173,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             # now mark the first message as read and check the whole conversation is now read
             Modifier.mark_message_as_read(conversation[0].serialize(self.user_respondent), self.user_respondent)
             con = Retriever.retrieve_thread(conversation_id, self.user_respondent)
-            for msg in con.all():
+            for msg in con:
                 # message `read at` should now be set
                 self.assertIsNotNone(msg.read_at)
                 # collect the labels again
@@ -238,7 +238,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
         """testing message read_date is set when unread label is removed"""
         thread_id = self.populate_database(1, mark_as_read=False)
         with self.app.app_context():
-            thread = Retriever.retrieve_thread(thread_id, self.user_respondent).all()
+            thread = Retriever.retrieve_thread(thread_id, self.user_respondent)
             serialised_message = Retriever.retrieve_message(thread[0].msg_id, self.user_internal)
             Modifier.mark_message_as_read(serialised_message, self.user_internal)
             serialised_message = Retriever.retrieve_message(thread[0].msg_id, self.user_internal)

--- a/tests/app/test_retriever.py
+++ b/tests/app/test_retriever.py
@@ -235,7 +235,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         with self.app.app_context():
             with current_app.test_request_context():
                 response = Retriever.retrieve_thread(thread_id, self.user_respondent)
-                self.assertEqual(len(response.all()), 6)
+                self.assertEqual(len(response), 6)
 
     def test_thread_returned_in_desc_order(self):
         """check thread returned in correct order"""
@@ -244,9 +244,9 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
         with self.app.app_context():
             with current_app.test_request_context():
                 response = Retriever.retrieve_thread(thread_id, self.user_respondent)
-                self.assertEqual(len(response.all()), 6)
+                self.assertEqual(len(response), 6)
 
-                sent = [str(message.sent_at) for message in response.all()]
+                sent = [str(message.sent_at) for message in response]
 
                 desc_date = sorted(sent, reverse=True)
                 self.assertEqual(len(sent), 6)
@@ -354,7 +354,7 @@ class RetrieverTestCase(unittest.TestCase, RetrieverTestCaseHelper):
 
                 for x in range(0, len(thread_ids)):
                     thread = Retriever.retrieve_thread(thread_ids[x], self.user_internal)
-                    first_msg_in_thread = thread.all()[0]
+                    first_msg_in_thread = thread[0]
                     self.assertEqual(date[x], str(first_msg_in_thread.sent_at))
                     self.assertEqual(msg_ids[x], first_msg_in_thread.msg_id)
 

--- a/tests/endpoints/test_messages_endpoints.py
+++ b/tests/endpoints/test_messages_endpoints.py
@@ -1,0 +1,125 @@
+import unittest
+from unittest.mock import patch
+
+from flask import json
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+
+from secure_message import application, constants
+from secure_message.authentication.jwt import encode
+from secure_message.exception.exceptions import MessageSaveException
+from secure_message.repository import database
+from secure_message.repository.database import SecureMessage
+from secure_message.services.service_toggles import party
+
+message_modify_url = "http://localhost:5050/messages/modify/"
+
+
+class TestMessagesEndpoints(unittest.TestCase):
+    BRES_SURVEY = "33333333-22222-3333-4444-88dc018a1a4c"
+    SPECIFIC_INTERNAL_USER = "SpecificInternalUserId"
+
+    def setUp(self):
+        """setup test environment"""
+        self.app = application.create_app(config="TestConfig")
+        self.client = self.app.test_client()
+        self.engine = create_engine(self.app.config["SQLALCHEMY_DATABASE_URI"])
+
+        internal_token_data = {
+            constants.USER_IDENTIFIER: TestMessagesEndpoints.SPECIFIC_INTERNAL_USER,
+            "role": "internal",
+        }
+
+        with self.app.app_context():
+            internal_signed_jwt = encode(internal_token_data)
+
+        self.internal_user_header = {"Content-Type": "application/json", "Authorization": internal_signed_jwt}
+
+        self.test_message = {
+            "msg_to": ["0a7ad740-10d5-4ecb-b7ca-3c0384afb882"],
+            "msg_from": TestMessagesEndpoints.SPECIFIC_INTERNAL_USER,
+            "subject": "MyMessage",
+            "body": "hello",
+            "thread_id": "",
+            "case_id": "ACollectionCase",
+            "exercise_id": "ACollectionExercise",
+            "business_id": "f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
+            "survey_id": self.BRES_SURVEY,
+        }
+
+        with self.app.app_context():
+            database.db.drop_all()
+            database.db.create_all()
+            self.db = database.db
+
+        party.use_mock_service()
+
+    @patch("secure_message.repository.saver.Saver.save_message")
+    def test_message_post_raises_message_exception(self, mock_message_save):
+        mock_message_save.side_effect = MessageSaveException("Message save failed")
+        url = "http://localhost:5050/messages"
+
+        response = self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn("Messages service error".encode(), response.data)
+
+    @patch("secure_message.repository.retriever.Retriever.retrieve_populated_message_object")
+    def test_message_patch_retrieval_raises_sql_exception(self, mock_retrieve_message):
+        mock_retrieve_message.side_effect = SQLAlchemyError()
+        url = "http://localhost:5050/messages/f1a5e99c-8edf-489a-9c72-6cabe6c387fc"
+        payload = {
+            "business_id": "b4db7171-bba1-497c-8343-7d9ddfe19653",
+            "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d",
+        }
+        response = self.client.patch(url, json=payload, headers=self.internal_user_header)
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("SQLAlchemyError".encode(), response.data)
+        self.assertIn("Messages service error".encode(), response.data)
+
+    @patch("secure_message.repository.modifier.Modifier.patch_message")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_populated_message_object")
+    def test_message_patch_raises_sql_exception(self, mock_patch_message, mock_retrieve_message):
+        mock_retrieve_message.return_value = SecureMessage(
+            msg_id="f1a5e99c-8edf-489a-9c72-6cabe6c387fc",
+            subject="Something else",
+            body="test",
+            thread_id="6b358b03-2647-48ae-929f-10c1d8b7d1d9",
+            case_id="",
+            business_id="b4db7171-bba1-497c-8343-7d9ddfe19653",
+            exercise_id="",
+            survey_id="02b9c366-7397-42f7-942a-76dc5876d86d",
+            from_internal=False,
+        )
+        mock_patch_message.side_effect = SQLAlchemyError()
+        url = "http://localhost:5050/messages/f1a5e99c-8edf-489a-9c72-6cabe6c387fc"
+        response = self.client.patch(url, data=json.dumps({"is_closed": True}), headers=self.internal_user_header)
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("SQLAlchemyError".encode(), response.data)
+        self.assertIn("Messages service error".encode(), response.data)
+
+    @patch("secure_message.repository.retriever.Retriever.retrieve_message")
+    @patch("secure_message.repository.modifier.Modifier.add_unread")
+    def test_modify_unread_label_raises_sql_exception(self, mock_add_unread, mock_retrieve_message):
+        url = f"{message_modify_url}f1a5e99c-8edf-489a-9c72-6cabe6c387fc"
+        test_message_copy = self.test_message.copy()
+        test_message_copy["msg_to"] = ["GROUP"]
+        mock_retrieve_message.return_value = test_message_copy
+        mock_add_unread.side_effect = SQLAlchemyError()
+        data = {"label": "UNREAD", "action": "add"}
+        response = self.client.put(url, json=data, headers=self.internal_user_header)
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("Messages service error".encode(), response.data)
+
+    @patch("secure_message.repository.retriever.Retriever.retrieve_message")
+    @patch("secure_message.repository.modifier.Modifier.mark_message_as_read")
+    def test_mark_as_read_raises_sql_exception(self, mock_mark_as_read, mock_retrieve_message):
+        url = f"{message_modify_url}f1a5e99c-8edf-489a-9c72-6cabe6c387fc"
+        test_message_copy = self.test_message.copy()
+        test_message_copy["msg_to"] = ["GROUP"]
+        mock_retrieve_message.return_value = test_message_copy
+        mock_mark_as_read.side_effect = SQLAlchemyError()
+        data = {"label": "UNREAD", "action": "remove"}
+        response = self.client.put(url, json=data, headers=self.internal_user_header)
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("Messages service error".encode(), response.data)

--- a/tests/endpoints/test_messages_endpoints.py
+++ b/tests/endpoints/test_messages_endpoints.py
@@ -62,7 +62,10 @@ class TestMessagesEndpoints(unittest.TestCase):
         response = self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)
 
         self.assertEqual(500, response.status_code)
-        self.assertIn("Messages service error".encode(), response.data)
+        self.assertEqual(
+            {"detail": "MessageSaveException", "title": "Message save error when sending a message"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.retriever.Retriever.retrieve_populated_message_object")
     def test_message_patch_retrieval_raises_sql_exception(self, mock_retrieve_message):
@@ -74,8 +77,10 @@ class TestMessagesEndpoints(unittest.TestCase):
         }
         response = self.client.patch(url, json=payload, headers=self.internal_user_header)
         self.assertEqual(response.status_code, 500)
-        self.assertIn("SQLAlchemyError".encode(), response.data)
-        self.assertIn("Messages service error".encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying message"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.modifier.Modifier.patch_message")
     @patch("secure_message.repository.retriever.Retriever.retrieve_populated_message_object")
@@ -95,8 +100,10 @@ class TestMessagesEndpoints(unittest.TestCase):
         url = "http://localhost:5050/messages/f1a5e99c-8edf-489a-9c72-6cabe6c387fc"
         response = self.client.patch(url, data=json.dumps({"is_closed": True}), headers=self.internal_user_header)
         self.assertEqual(response.status_code, 500)
-        self.assertIn("SQLAlchemyError".encode(), response.data)
-        self.assertIn("Messages service error".encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying message"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.retriever.Retriever.retrieve_message")
     @patch("secure_message.repository.modifier.Modifier.add_unread")
@@ -109,7 +116,10 @@ class TestMessagesEndpoints(unittest.TestCase):
         data = {"label": "UNREAD", "action": "add"}
         response = self.client.put(url, json=data, headers=self.internal_user_header)
         self.assertEqual(response.status_code, 500)
-        self.assertIn("Messages service error".encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when updating message status"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.retriever.Retriever.retrieve_message")
     @patch("secure_message.repository.modifier.Modifier.mark_message_as_read")
@@ -122,4 +132,7 @@ class TestMessagesEndpoints(unittest.TestCase):
         data = {"label": "UNREAD", "action": "remove"}
         response = self.client.put(url, json=data, headers=self.internal_user_header)
         self.assertEqual(response.status_code, 500)
-        self.assertIn("Messages service error".encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when updating message status"},
+            json.loads(response.get_data()),
+        )

--- a/tests/endpoints/test_threads_endpoints.py
+++ b/tests/endpoints/test_threads_endpoints.py
@@ -1,0 +1,218 @@
+import unittest
+from unittest.mock import patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+
+from secure_message import application, constants
+from secure_message.authentication.jwt import encode
+from secure_message.repository import database
+from secure_message.repository.database import Conversation, SecureMessage
+
+
+class TestThreadsEndpoints(unittest.TestCase):
+    SPECIFIC_INTERNAL_USER = "SpecificInternalUserId"
+    SQL_ERROR = '{"detail":"SQLAlchemyError","title":"Thread service error"}'
+
+    def setUp(self):
+        self.app = application.create_app(config="TestConfig")
+        self.client = self.app.test_client()
+        self.engine = create_engine(self.app.config["SQLALCHEMY_DATABASE_URI"])
+
+        internal_token_data = {
+            constants.USER_IDENTIFIER: TestThreadsEndpoints.SPECIFIC_INTERNAL_USER,
+            "role": "internal",
+        }
+
+        with self.app.app_context():
+            internal_signed_jwt = encode(internal_token_data)
+
+        self.internal_user_header = {"Content-Type": "application/json", "Authorization": internal_signed_jwt}
+
+        self.conversation = [
+            SecureMessage(
+                msg_id="59f79039-05ab-4ce1-8354-ab9e7c64d925",
+                subject="Something else",
+                body="test",
+                thread_id="59f79039-05ab-4ce1-8354-ab9e7c64d925",
+                case_id="",
+                business_id="65c1070f-af33-4c15-a36c-88da9c2d8e4d",
+                exercise_id="",
+                survey_id="02b9c366-7397-42f7-942a-76dc5876d86d",
+                from_internal=False,
+                read_at=None,
+            )
+        ]
+
+        self.open_conversation_metadata = Conversation(
+            is_closed=False, closed_by=None, closed_by_uuid=None, closed_at=None, category="SURVEY"
+        )
+
+        self.closed_conversation_metadata = Conversation(
+            is_closed=True, closed_by=None, closed_by_uuid=None, closed_at=None, category="SURVEY"
+        )
+
+        self.serialized_message = {
+            "msg_to": ["GROUP"],
+            "msg_from": "5b7156d1-202c-4c62-a2af-522cdd68c038",
+            "msg_id": "b4f8e3dd-c5f6-4751-811f-36af7313f3f0",
+            "subject": "Something else",
+            "body": "test",
+            "thread_id": "59f79039-05ab-4ce1-8354-ab9e7c64d925",
+            "case_id": "",
+            "business_id": "65c1070f-af33-4c15-a36c-88da9c2d8e4d",
+            "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d",
+            "exercise_id": "",
+            "from_internal": False,
+            "sent_date": "2024-02-27 16:22:20.586406",
+            "read_date": "2024-02-27 16:24:31.314681",
+            "_links": "",
+            "labels": ["INBOX"],
+        }
+
+        with self.app.app_context():
+            database.db.drop_all()
+            database.db.create_all()
+            self.db = database.db
+
+    @patch("secure_message.repository.retriever.Retriever.retrieve_thread")
+    def test_get_thread_retrieval_raises_sql_exception(self, mock_retriever):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_retriever.side_effect = SQLAlchemyError()
+
+        response = self.client.get(url, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn("Database error while retrieving message thread".encode(), response.data)
+
+    @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_thread")
+    def test_get_conversation_metadata_retrieval_raises_sql_exception(
+        self, mock_retriever, mock_conversation_metadata_retriever
+    ):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_retriever.side_effect = self.conversation
+        mock_conversation_metadata_retriever.side_effect = SQLAlchemyError()
+
+        response = self.client.get(url, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn("Database error while retrieving message thread".encode(), response.data)
+
+    @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
+    def test_patch_thread_conversation_metadata_retrieval_raises_sql_exception(
+        self, mock_conversation_metadata_retriever
+    ):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_conversation_metadata_retriever.side_effect = SQLAlchemyError()
+        payload = {"is_closed": True}
+
+        response = self.client.patch(url, json=payload, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn(self.SQL_ERROR.encode(), response.data)
+
+    @patch("secure_message.repository.modifier.Modifier.patch_conversation")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
+    def test_patch_thread_patch_conversation_raises_sql_exception(
+        self, mock_conversation_metadata_retriever, mock_patch_conversation
+    ):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_conversation_metadata_retriever.return_value = self.open_conversation_metadata
+        mock_patch_conversation.side_effect = SQLAlchemyError()
+        payload = {"is_closed": True}
+
+        response = self.client.patch(url, json=payload, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn(self.SQL_ERROR.encode(), response.data)
+
+    @patch("secure_message.repository.modifier.Modifier.close_conversation")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
+    def test_patch_thread_close_conversation_raises_sql_exception(
+        self, mock_conversation_metadata_retriever, mock_close_conversation
+    ):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_conversation_metadata_retriever.return_value = self.open_conversation_metadata
+        mock_close_conversation.side_effect = SQLAlchemyError()
+        payload = {"is_closed": True}
+
+        response = self.client.patch(url, json=payload, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn(self.SQL_ERROR.encode(), response.data)
+
+    @patch("secure_message.repository.modifier.Modifier.open_conversation")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
+    def test_patch_thread_open_conversation_raises_sql_exception(
+        self, mock_conversation_metadata_retriever, mock_open_conversation
+    ):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_conversation_metadata_retriever.return_value = self.closed_conversation_metadata
+        mock_open_conversation.side_effect = SQLAlchemyError()
+        payload = {"is_closed": False}
+
+        response = self.client.patch(url, json=payload, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn(self.SQL_ERROR.encode(), response.data)
+
+    @patch("secure_message.repository.retriever.Retriever.retrieve_thread")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
+    def test_patch_thread_retrieve_thread_raises_sql_exception(
+        self, mock_conversation_metadata_retriever, mock_retrieve_thread
+    ):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_conversation_metadata_retriever.return_value = self.closed_conversation_metadata
+        mock_retrieve_thread.side_effect = SQLAlchemyError()
+        payload = {"category": "TECHNICAL"}
+
+        response = self.client.patch(url, json=payload, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn(self.SQL_ERROR.encode(), response.data)
+
+    @patch("secure_message.repository.database.SecureMessage.serialize")
+    @patch("secure_message.repository.modifier.Modifier.add_unread")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_thread")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
+    def test_patch_add_unread_thread_raises_sql_exception(
+        self, mock_conversation_metadata_retriever, mock_retrieve_thread, mock_add_unread, mock_serialize
+    ):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_conversation_metadata_retriever.return_value = self.closed_conversation_metadata
+        mock_retrieve_thread.return_value = self.conversation
+        mock_serialize.return_value = self.serialized_message
+        mock_add_unread.side_effect = SQLAlchemyError()
+        payload = {"category": "TECHNICAL"}
+
+        response = self.client.patch(url, json=payload, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn(self.SQL_ERROR.encode(), response.data)
+
+    @patch("secure_message.repository.modifier.Modifier.patch_message")
+    @patch("secure_message.repository.modifier.Modifier.add_unread")
+    @patch("secure_message.repository.database.SecureMessage.serialize")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_thread")
+    @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
+    def test_patch_message_thread_raises_sql_exception(
+        self,
+        mock_conversation_metadata_retriever,
+        mock_retrieve_thread,
+        mock_serialize,
+        mock_add_unread,
+        mock_patch_message,
+    ):
+        url = "http://localhost:5050/threads/59f79039-05ab-4ce1-8354-ab9e7c64d925"
+        mock_conversation_metadata_retriever.return_value = self.closed_conversation_metadata
+        mock_retrieve_thread.return_value = self.conversation
+        mock_serialize.return_value = self.serialized_message
+        mock_add_unread.return_value = None
+        mock_patch_message.side_effect = SQLAlchemyError
+        payload = {"category": "TECHNICAL"}
+
+        response = self.client.patch(url, json=payload, headers=self.internal_user_header)
+
+        self.assertEqual(500, response.status_code)
+        self.assertIn(self.SQL_ERROR.encode(), response.data)

--- a/tests/endpoints/test_threads_endpoints.py
+++ b/tests/endpoints/test_threads_endpoints.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from unittest.mock import patch
 
@@ -110,7 +111,10 @@ class TestThreadsEndpoints(unittest.TestCase):
         response = self.client.patch(url, json=payload, headers=self.internal_user_header)
 
         self.assertEqual(500, response.status_code)
-        self.assertIn(self.SQL_ERROR.encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying thread"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.modifier.Modifier.patch_conversation")
     @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
@@ -125,7 +129,10 @@ class TestThreadsEndpoints(unittest.TestCase):
         response = self.client.patch(url, json=payload, headers=self.internal_user_header)
 
         self.assertEqual(500, response.status_code)
-        self.assertIn(self.SQL_ERROR.encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying thread"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.modifier.Modifier.close_conversation")
     @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
@@ -140,7 +147,10 @@ class TestThreadsEndpoints(unittest.TestCase):
         response = self.client.patch(url, json=payload, headers=self.internal_user_header)
 
         self.assertEqual(500, response.status_code)
-        self.assertIn(self.SQL_ERROR.encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying thread"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.modifier.Modifier.open_conversation")
     @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
@@ -155,7 +165,10 @@ class TestThreadsEndpoints(unittest.TestCase):
         response = self.client.patch(url, json=payload, headers=self.internal_user_header)
 
         self.assertEqual(500, response.status_code)
-        self.assertIn(self.SQL_ERROR.encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying thread"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.retriever.Retriever.retrieve_thread")
     @patch("secure_message.repository.retriever.Retriever.retrieve_conversation_metadata")
@@ -170,7 +183,10 @@ class TestThreadsEndpoints(unittest.TestCase):
         response = self.client.patch(url, json=payload, headers=self.internal_user_header)
 
         self.assertEqual(500, response.status_code)
-        self.assertIn(self.SQL_ERROR.encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying thread"},
+            json.loads(response.get_data()),
+        )
 
     @patch("secure_message.repository.database.SecureMessage.serialize")
     @patch("secure_message.repository.modifier.Modifier.add_unread")
@@ -189,7 +205,9 @@ class TestThreadsEndpoints(unittest.TestCase):
         response = self.client.patch(url, json=payload, headers=self.internal_user_header)
 
         self.assertEqual(500, response.status_code)
-        self.assertIn(self.SQL_ERROR.encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying thread"}, json.loads(response.data)
+        )
 
     @patch("secure_message.repository.modifier.Modifier.patch_message")
     @patch("secure_message.repository.modifier.Modifier.add_unread")
@@ -215,4 +233,7 @@ class TestThreadsEndpoints(unittest.TestCase):
         response = self.client.patch(url, json=payload, headers=self.internal_user_header)
 
         self.assertEqual(500, response.status_code)
-        self.assertIn(self.SQL_ERROR.encode(), response.data)
+        self.assertEqual(
+            {"detail": "SQLAlchemyError", "title": "Database error when modifying thread"},
+            json.loads(response.get_data()),
+        )


### PR DESCRIPTION
# What and why?
Adds error handling around database errors and tests around this. Also updated the GHA workflow with the new `setup-gcloud` and replaces how we create the release
# How to test?
I haven't found a way to test this easily when deployed through spinnaker as other services fall over when there is a database connection issue (I cause this by deleting the postgres configmap). Instead I deploy the secure message PR locally and either insert `raise SQLAlchemyError` where it's being tested or then stop the local postgres deployment
- update uaa client secret so that secure message can connect to uaa on startup
- run local postgres, securemessage, rOps and/or frontstage
- make a SQLAlchemyError happen
- make sure that the whole stack trace is not printed to the logs
# Jira
[RAS-1031](https://jira.ons.gov.uk/browse/RAS-1031)