### PR TITLE
RAS-1238 Update to docker compose from docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pipenv run python run.py
 ```
 or
 ```bash
-docker-compose up
+docker compose up
 ```
 or (when postgres is set up)
 ```bash
@@ -64,7 +64,7 @@ docker run -d -p 5432:5432 --name postgres -e POSTGRES_PASSWORD=postgres -e POST
 ```
 or you can use the docker-compose.yml file to create postgres
 ```bash
-docker-compose up
+docker compose up
 ```
 
 Run the tests with make

--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.72
+version: 2.1.73
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.72
+appVersion: 2.1.73


### PR DESCRIPTION
# What and why?
Updating references to the now removed `docker-compose` in favour of `docker compose`
# How to test?
No functional changes
# Jira
[RAS-1238](https://jira.ons.gov.uk/browse/RAS-1238)