### PR TITLE
RAS-1839 Introduce scheduled job to mark closed conversations for del…

### DIFF
--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.98
+version: 2.1.99
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.98
+appVersion: 2.1.99

--- a/_infra/helm/secure-message/templates/cronjob_closed_conversations_mark_for_deletion.yaml
+++ b/_infra/helm/secure-message/templates/cronjob_closed_conversations_mark_for_deletion.yaml
@@ -3,7 +3,6 @@ kind: CronJob
 metadata:
   name: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.name }}
 spec:
-  suspend: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.suspend }}
   schedule: "{{ .Values.crons.closedConversationsMarkForDeletionScheduler.cron }}"
   jobTemplate:
     spec:

--- a/_infra/helm/secure-message/templates/cronjob_closed_conversations_mark_for_deletion.yaml
+++ b/_infra/helm/secure-message/templates/cronjob_closed_conversations_mark_for_deletion.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.name }}
+spec:
+  suspend: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.suspend }}
+  schedule: "{{ .Values.crons.closedConversationsMarkForDeletionScheduler.cron }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.name }}
+            image: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images/alpine-curl:latest
+            env:
+            - name: SECURITY_USER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: security-credentials
+                  key: security-user
+            - name: SECURITY_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: security-credentials
+                  key: security-password
+            - name: TARGET
+              value: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.target }}
+            args:
+            - /bin/sh
+            - -c
+            - curl -s -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X POST http://$(SECURE_MESSAGE_SERVICE_HOST):$(SECURE_MESSAGE_SERVICE_PORT)/$(TARGET)
+          restartPolicy: OnFailure

--- a/_infra/helm/secure-message/templates/deployment.yaml
+++ b/_infra/helm/secure-message/templates/deployment.yaml
@@ -187,5 +187,7 @@ spec:
                 key: client-secret
           - name: LOGGING_LEVEL
             value: "{{ .Values.app.config.loggingLevel }}"
+          - name: MARK_FOR_DELETION_OFFSET_IN_DAYS
+            value: "{{ .Values.markForDeletionOffsetInDays }}"
           resources:
             {{ toYaml .Values.resources.application | nindent 12 }}

--- a/_infra/helm/secure-message/values.yaml
+++ b/_infra/helm/secure-message/values.yaml
@@ -65,3 +65,10 @@ dns:
 app:
   config:
     loggingLevel: "INFO"
+
+crons:
+  closedConversationsMarkForDeletionScheduler:
+    name: sm-closed-conversations-mark-for-deletion
+    cron: "0 0 * * *"
+    target: "/threads/closed/mark_for_deletion"
+    suspend: true

--- a/_infra/helm/secure-message/values.yaml
+++ b/_infra/helm/secure-message/values.yaml
@@ -71,4 +71,3 @@ crons:
     name: sm-closed-conversations-mark-for-deletion
     cron: "0 0 * * *"
     target: "/threads/closed/mark_for_deletion"
-    suspend: true

--- a/config.py
+++ b/config.py
@@ -55,6 +55,7 @@ class Config:
 
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT", "ras-rm-sandbox")
     PUBSUB_TOPIC = os.getenv("PUBSUB_TOPIC", "ras-rm-notify-test")
+    MARK_FOR_DELETION_OFFSET_IN_DAYS = os.getenv("MARK_FOR_DELETION_OFFSET_IN_DAYS", 30)
 
 
 class DevConfig(Config):

--- a/secure_message/application.py
+++ b/secure_message/application.py
@@ -168,6 +168,7 @@ def _request_requires_authentication():
         request.endpoint is not None
         and "health" not in request.endpoint
         and request.endpoint != "info"
+        and request.endpoint != "threadmarkfordeletion"
         and request.method != "OPTIONS"
     )
 

--- a/secure_message/application.py
+++ b/secure_message/application.py
@@ -25,7 +25,12 @@ from secure_message.resources.messages import (
     MessageModifyById,
     MessageSend,
 )
-from secure_message.resources.threads import ThreadById, ThreadCounter, ThreadList
+from secure_message.resources.threads import (
+    ThreadById,
+    ThreadCounter,
+    ThreadList,
+    ThreadMarkForDeletion,
+)
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -62,6 +67,7 @@ def create_app(config=None):
     api.add_resource(ThreadList, "/threads")
     api.add_resource(ThreadById, "/threads/<thread_id>")
     api.add_resource(ThreadCounter, "/messages/count")
+    api.add_resource(ThreadMarkForDeletion, "/threads/closed/mark_for_deletion")
 
     app.oauth_client_token_expires_at = maya.now()
 

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -1,6 +1,8 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import Final
 
+from flask import current_app
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from structlog import wrap_logger
@@ -229,3 +231,24 @@ class Modifier:
 
         bound_logger.info("Successfully re-opened conversation")
         bound_logger.unbind("conversation_id", "user_id")
+
+    @staticmethod
+    def closed_conversations_mark_for_deletion() -> int:
+        """
+        Mark closed conversations for deletion based on configured offset.
+        """
+        now: datetime = datetime.now()
+        offset_days: Final[int] = current_app.config["MARK_FOR_DELETION_OFFSET_IN_DAYS"]
+        cutoff_date: datetime = now - timedelta(days=offset_days)
+
+        try:
+            updated_count: int = Conversation.query.filter(Conversation.closed_at < cutoff_date).update(
+                {Conversation.mark_for_deletion: True},
+            )
+            db.session.commit()
+            return updated_count
+
+        except SQLAlchemyError:
+            db.session.rollback()
+            logger.exception("Failed to mark conversations for deletion")
+            raise

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -238,7 +238,7 @@ class Modifier:
         Mark closed conversations for deletion based on configured offset.
         """
         now: datetime = datetime.now()
-        offset_days: Final[int] = current_app.config["MARK_FOR_DELETION_OFFSET_IN_DAYS"]
+        offset_days: Final[int] = int(current_app.config["MARK_FOR_DELETION_OFFSET_IN_DAYS"])
         cutoff_date: datetime = now - timedelta(days=offset_days)
 
         try:

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -204,3 +204,16 @@ class ThreadCounter(Resource):
             return make_response(
                 jsonify({"title": "Database error when getting thread counts", "detail": e.__class__.__name__}), 500
             )
+
+
+class ThreadMarkForDeletion(Resource):
+    @staticmethod
+    def post():
+        try:
+            conversation_count = Modifier.closed_conversations_mark_for_deletion()
+            logger.info(f"{conversation_count} conversations marked for deletion")
+            return "", 204
+
+        except SQLAlchemyError:
+            logger.exception("Failed to mark conversations for deletion")
+            return "", 500

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -9,7 +9,7 @@ from werkzeug.exceptions import InternalServerError
 from secure_message import constants
 from secure_message.application import create_app
 from secure_message.repository import database
-from secure_message.repository.database import SecureMessage
+from secure_message.repository.database import SecureMessage, db
 from secure_message.repository.modifier import Modifier
 from secure_message.repository.retriever import Retriever
 from secure_message.services.service_toggles import internal_user_service
@@ -370,6 +370,42 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
 
         with self.assertRaises(InternalServerError):
             Modifier._get_label_actor(user=self.user_internal, message=message_missing_fields)
+
+    def test_closed_conversations_mark_for_deletion(self):
+
+        # Given 4 conversations are created (1 open, 3 closed or which 2 should be marked for deletion)
+        with self.app.app_context():
+            offset = current_app.config["MARK_FOR_DELETION_OFFSET_IN_DAYS"]
+            now = datetime.datetime.utcnow()
+
+            greater_than_deletion_date = now - datetime.timedelta(days=offset + 1)
+            less_than_deletion_date = now - datetime.timedelta(days=offset - 1)
+
+            conv1 = database.Conversation(is_closed=True, closed_at=greater_than_deletion_date)
+            conv1.id = "1"
+            conv2 = database.Conversation(is_closed=True, closed_at=greater_than_deletion_date)
+            conv2.id = "2"
+            conv3 = database.Conversation(is_closed=True, closed_at=less_than_deletion_date)
+            conv3.id = "3"
+            conv4 = database.Conversation(is_closed=False)
+            conv4.id = "4"
+            db.session.add_all([conv1, conv2, conv3, conv4])
+            db.session.commit()
+
+            # When closed_conversations_mark_for_deletion is called
+            updated_count = Modifier.closed_conversations_mark_for_deletion()
+
+            # Then 2 conversations are updated, with mark_for_deletion set to True
+            self.assertEqual(updated_count, 2)
+
+            refreshed = {
+                conv.id: db.session.get(database.Conversation, conv.id) for conv in [conv1, conv2, conv3, conv4]
+            }
+
+            self.assertTrue(refreshed["1"].mark_for_deletion)
+            self.assertTrue(refreshed["2"].mark_for_deletion)
+            self.assertFalse(refreshed["3"].mark_for_deletion)
+            self.assertFalse(refreshed["4"].mark_for_deletion)
 
 
 if __name__ == "__main__":

--- a/tests/endpoints/test_threads_endpoints.py
+++ b/tests/endpoints/test_threads_endpoints.py
@@ -9,6 +9,7 @@ from secure_message import application, constants
 from secure_message.authentication.jwt import encode
 from secure_message.repository import database
 from secure_message.repository.database import Conversation, SecureMessage
+from secure_message.resources.threads import ThreadMarkForDeletion
 
 
 class TestThreadsEndpoints(unittest.TestCase):
@@ -46,11 +47,21 @@ class TestThreadsEndpoints(unittest.TestCase):
         ]
 
         self.open_conversation_metadata = Conversation(
-            is_closed=False, closed_by=None, closed_by_uuid=None, closed_at=None, category="SURVEY", mark_for_deletion=False
+            is_closed=False,
+            closed_by=None,
+            closed_by_uuid=None,
+            closed_at=None,
+            category="SURVEY",
+            mark_for_deletion=False,
         )
 
         self.closed_conversation_metadata = Conversation(
-            is_closed=True, closed_by=None, closed_by_uuid=None, closed_at=None, category="SURVEY", mark_for_deletion=False
+            is_closed=True,
+            closed_by=None,
+            closed_by_uuid=None,
+            closed_at=None,
+            category="SURVEY",
+            mark_for_deletion=False,
         )
 
         self.serialized_message = {
@@ -237,3 +248,29 @@ class TestThreadsEndpoints(unittest.TestCase):
             {"detail": "SQLAlchemyError", "title": "Database error when modifying thread"},
             json.loads(response.get_data()),
         )
+
+    @patch("secure_message.repository.modifier.Modifier.closed_conversations_mark_for_deletion")
+    def test_conversation_mark_for_deletion_success(self, closed_conversations_mark_for_deletion):
+        # Given a mocked value of 1 is returned from closed_conversations_mark_for_deletion
+        closed_conversations_mark_for_deletion.return_value = 1
+
+        # When ThreadMarkForDeletion post is called
+        response, status_code = ThreadMarkForDeletion.post()
+
+        # Then a 204 response is returned
+        self.assertEqual(status_code, 204)
+        self.assertEqual(response, "")
+        closed_conversations_mark_for_deletion.assert_called_once()
+
+    @patch("secure_message.repository.modifier.Modifier.closed_conversations_mark_for_deletion")
+    def test_conversation_mark_for_deletion_failure(self, closed_conversations_mark_for_deletion):
+        # Given a mocked side effect of an  SQLAlchemyError
+        closed_conversations_mark_for_deletion.side_effect = SQLAlchemyError()
+
+        # When ThreadMarkForDeletion post is called
+        response, status_code = ThreadMarkForDeletion.post()
+
+        # Then a 500 error is returned
+        self.assertEqual(status_code, 500)
+        self.assertEqual(response, "")
+        closed_conversations_mark_for_deletion.assert_called_once()


### PR DESCRIPTION
# What and why?
This PR introduces a cron job and an end point to mark conversation ready for deletion
# How to test?
Using the spinnaker pipline "Deploy Version and Helm Chart" deploy this PR with the config branch https://github.com/ONSdigital/ras-rm-config/pull/311, then test the cron job using different secure message states to make sure it works correctly (open, closed, old, new etc) 

<img width="832" height="95" alt="Screenshot 2026-03-30 at 12 35 25" src="https://github.com/user-attachments/assets/1ca4510f-c0fc-423b-830a-1ac3e42ee7d9" />


# Jira
