### PR TITLE
RAS-1878 Scheduled job to delete conversations marked for deletion

### DIFF
--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.100
+version: 2.1.101
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.100
+appVersion: 2.1.101

--- a/_infra/helm/secure-message/templates/cronjob_closed_conversations_deletion.yaml
+++ b/_infra/helm/secure-message/templates/cronjob_closed_conversations_deletion.yaml
@@ -1,15 +1,15 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.name }}
+  name: {{ .Values.crons.closedConversationsDeletionScheduler.name }}
 spec:
-  schedule: "{{ .Values.crons.closedConversationsMarkForDeletionScheduler.cron }}"
+  schedule: "{{ .Values.crons.closedConversationsDeletionScheduler.cron }}"
   jobTemplate:
     spec:
       template:
         spec:
           containers:
-          - name: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.name }}
+          - name: {{ .Values.crons.closedConversationsDeletionScheduler.name }}
             image: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images/alpine-curl:latest
             env:
             - name: SECURITY_USER_NAME
@@ -23,9 +23,9 @@ spec:
                   name: security-credentials
                   key: security-password
             - name: TARGET
-              value: {{ .Values.crons.closedConversationsMarkForDeletionScheduler.target }}
+              value: {{ .Values.crons.closedConversationsDeletionScheduler.target }}
             args:
             - /bin/sh
             - -c
-            - curl -s -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X POST http://$(SECURE_MESSAGE_SERVICE_HOST):$(SECURE_MESSAGE_SERVICE_PORT)$(TARGET)
+            - curl -s -u $(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD) -X DELETE http://$(SECURE_MESSAGE_SERVICE_HOST):$(SECURE_MESSAGE_SERVICE_PORT)$(TARGET)
           restartPolicy: OnFailure

--- a/_infra/helm/secure-message/values.yaml
+++ b/_infra/helm/secure-message/values.yaml
@@ -69,5 +69,9 @@ app:
 crons:
   closedConversationsMarkForDeletionScheduler:
     name: sm-closed-conversations-mark-for-deletion
-    cron: "0 0 * * *"
+    cron: "0 1 * * *"
     target: "/threads/closed/mark_for_deletion"
+  closedConversationsDeletionScheduler:
+    name: sm-closed-conversations-deletion
+    cron: "0 0 * * *"
+    target: "/threads/closed/delete"

--- a/secure_message/application.py
+++ b/secure_message/application.py
@@ -28,6 +28,7 @@ from secure_message.resources.messages import (
 from secure_message.resources.threads import (
     ThreadById,
     ThreadCounter,
+    ThreadDeletion,
     ThreadList,
     ThreadMarkForDeletion,
 )
@@ -68,6 +69,7 @@ def create_app(config=None):
     api.add_resource(ThreadById, "/threads/<thread_id>")
     api.add_resource(ThreadCounter, "/messages/count")
     api.add_resource(ThreadMarkForDeletion, "/threads/closed/mark_for_deletion")
+    api.add_resource(ThreadDeletion, "/threads/closed/delete")
 
     app.oauth_client_token_expires_at = maya.now()
 
@@ -169,6 +171,7 @@ def _request_requires_authentication():
         and "health" not in request.endpoint
         and request.endpoint != "info"
         and request.endpoint != "threadmarkfordeletion"
+        and request.endpoint != "threaddeletion"
         and request.method != "OPTIONS"
     )
 

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import Final
 
 from flask import current_app
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.exc import SQLAlchemyError
 from structlog import wrap_logger
 from werkzeug.exceptions import BadRequest, InternalServerError
@@ -251,4 +251,34 @@ class Modifier:
         except SQLAlchemyError:
             db.session.rollback()
             logger.exception("Failed to mark conversations for deletion")
+            raise
+
+    @staticmethod
+    def closed_conversations_deletion() -> int:
+        """
+        Delete conversations, secure messages, and statuses that are marked for deletion.
+        """
+        session = db.session
+        try:
+            conversations_to_delete = select(Conversation.id).where(Conversation.mark_for_deletion.is_(True))
+            messages_to_delete = select(SecureMessage.msg_id).where(
+                SecureMessage.thread_id.in_(conversations_to_delete)
+            )
+
+            session.query(Status).filter(Status.msg_id.in_(messages_to_delete)).delete(synchronize_session=False)
+            session.query(SecureMessage).filter(SecureMessage.thread_id.in_(conversations_to_delete)).delete(
+                synchronize_session=False
+            )
+            deleted_count = (
+                session.query(Conversation)
+                .filter(Conversation.id.in_(conversations_to_delete))
+                .delete(synchronize_session=False)
+            )
+
+            session.commit()
+            return deleted_count
+
+        except SQLAlchemyError:
+            logger.exception("Failed to delete conversations, secure messages and statuses")
+            session.rollback()
             raise

--- a/secure_message/resources/threads.py
+++ b/secure_message/resources/threads.py
@@ -217,3 +217,16 @@ class ThreadMarkForDeletion(Resource):
         except SQLAlchemyError:
             logger.exception("Failed to mark conversations for deletion")
             return "", 500
+
+
+class ThreadDeletion(Resource):
+    @staticmethod
+    def delete():
+        try:
+            deleted_count = Modifier.closed_conversations_deletion()
+            logger.info(f"{deleted_count} conversations deleted")
+            return "", 204
+
+        except SQLAlchemyError:
+            logger.exception("Failed to delete conversations")
+            return "", 500

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -484,7 +484,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             self.assertEqual(count(database.SecureMessage, msg_id=msg_id), 1)
             self.assertEqual(count(database.Status, msg_id=msg_id), 1)
 
-            # When closed_conversations_deletion is called, but an SQLAlchemyError is returned on deleting SecureMessages
+            # When closed_conversations_deletion is called, but an error is returned on deleting SecureMessages
             with patch(
                 "sqlalchemy.orm.query.Query.delete", side_effect=[1, SQLAlchemyError("secure message delete failed")]
             ):

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -411,7 +411,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             self.assertFalse(refreshed["4"].mark_for_deletion)
 
     def test_closed_conversations_deletion_cascades(self):
-        # Given a conversation which has been marked_for_deletion
+        # Given a conversation where mark_for_deletion is True
         with self.app.app_context():
             conversation_id = "conversation_id"
             msg_id = "msg_id"
@@ -429,21 +429,21 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             db.session.add_all([conversation, message, status])
             db.session.commit()
 
-            assert count(database.Conversation, id=conversation_id) == 1
-            assert count(database.SecureMessage, msg_id=msg_id) == 1
-            assert count(database.Status, msg_id=msg_id) == 1
+            self.assertEqual(count(database.Conversation, id=conversation_id), 1)
+            self.assertEqual(count(database.SecureMessage, msg_id=msg_id), 1)
+            self.assertEqual(count(database.Status, msg_id=msg_id), 1)
 
-            # When deletion runs
+            # When closed_conversations_deletion is called
             deleted_count = Modifier.closed_conversations_deletion()
 
             # Then the conversation, secure message and status associated with it are deleted
-            assert deleted_count == 1
-            assert count(database.Conversation, id=conversation_id) == 0
-            assert count(database.SecureMessage, msg_id=msg_id) == 0
-            assert count(database.Status, msg_id=msg_id) == 0
+            self.assertEqual(deleted_count, 1)
+            self.assertEqual(count(database.Conversation, id=conversation_id), 0)
+            self.assertEqual(count(database.SecureMessage, msg_id=msg_id), 0)
+            self.assertEqual(count(database.Status, msg_id=msg_id), 0)
 
     def test_closed_conversations_deletion_does_not_remove_unmarked_conversations(self):
-        # Given a conversation NOT marked_for_deletion
+        # Given a conversation where mark_for_deletion is False
         with self.app.app_context():
             conversation_id = "conversation_id"
             conversation = database.Conversation(
@@ -452,17 +452,18 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             conversation.id = conversation_id
             db.session.add(conversation)
             db.session.commit()
-            assert count(database.Conversation, id=conversation_id) == 1
 
-            # When deletion runs
+            self.assertEqual(count(database.Conversation, id=conversation_id), 1)
+
+            # When closed_conversations_deletion is called
             deleted_count = Modifier.closed_conversations_deletion()
 
             # Then the conversation is not deleted
-            assert deleted_count == 0
-            assert count(database.Conversation, id=conversation_id) == 1
+            self.assertEqual(deleted_count, 0)
+            self.assertEqual(count(database.Conversation, id=conversation_id), 1)
 
     def test_closed_conversations_deletion_rolls_back_on_message_delete_error(self):
-        # Given a conversation which has been marked_for_deletion
+        # Given a conversation where mark_for_deletion is True
         with self.app.app_context():
             conversation_id = "conversation_id"
             msg_id = "msg_id"
@@ -479,11 +480,11 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             db.session.add_all([conversation, message, status])
             db.session.commit()
 
-            assert count(database.Conversation, id=conversation_id) == 1
-            assert count(database.SecureMessage, msg_id=msg_id) == 1
-            assert count(database.Status, msg_id=msg_id) == 1
+            self.assertEqual(count(database.Conversation, id=conversation_id), 1)
+            self.assertEqual(count(database.SecureMessage, msg_id=msg_id), 1)
+            self.assertEqual(count(database.Status, msg_id=msg_id), 1)
 
-            # When deletion runs, but an SQLAlchemyError is return on deleting SecureMessages
+            # When closed_conversations_deletion is called, but an SQLAlchemyError is returned on deleting SecureMessages
             with patch(
                 "sqlalchemy.orm.query.Query.delete", side_effect=[1, SQLAlchemyError("secure message delete failed")]
             ):
@@ -491,9 +492,9 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
                     Modifier.closed_conversations_deletion()
 
             # Then the conversation, secure message and status associated with it are not deleted
-            assert count(database.Conversation, id=conversation_id) == 1
-            assert count(database.SecureMessage, msg_id=msg_id) == 1
-            assert count(database.Status, msg_id=msg_id) == 1
+            self.assertEqual(count(database.Conversation, id=conversation_id), 1)
+            self.assertEqual(count(database.SecureMessage, msg_id=msg_id), 1)
+            self.assertEqual(count(database.Status, msg_id=msg_id), 1)
 
 
 def count(model, **filters):

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -1,9 +1,12 @@
 import datetime
 import unittest
 import uuid
+from unittest.mock import patch
 
+import pytest
 from flask import current_app
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import InternalServerError
 
 from secure_message import constants
@@ -406,6 +409,95 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             self.assertTrue(refreshed["2"].mark_for_deletion)
             self.assertFalse(refreshed["3"].mark_for_deletion)
             self.assertFalse(refreshed["4"].mark_for_deletion)
+
+    def test_closed_conversations_deletion_cascades(self):
+        # Given a conversation which has been marked_for_deletion
+        with self.app.app_context():
+            conversation_id = "conversation_id"
+            msg_id = "msg_id"
+
+            conversation = database.Conversation(
+                mark_for_deletion=True,
+            )
+            conversation.id = conversation_id
+            message = database.SecureMessage(
+                msg_id=msg_id,
+                thread_id=conversation_id,
+            )
+            status = database.Status(msg_id=msg_id)
+
+            db.session.add_all([conversation, message, status])
+            db.session.commit()
+
+            assert count(database.Conversation, id=conversation_id) == 1
+            assert count(database.SecureMessage, msg_id=msg_id) == 1
+            assert count(database.Status, msg_id=msg_id) == 1
+
+            # When deletion runs
+            deleted_count = Modifier.closed_conversations_deletion()
+
+            # Then the conversation, secure message and status associated with it are deleted
+            assert deleted_count == 1
+            assert count(database.Conversation, id=conversation_id) == 0
+            assert count(database.SecureMessage, msg_id=msg_id) == 0
+            assert count(database.Status, msg_id=msg_id) == 0
+
+    def test_closed_conversations_deletion_does_not_remove_unmarked_conversations(self):
+        # Given a conversation NOT marked_for_deletion
+        with self.app.app_context():
+            conversation_id = "conversation_id"
+            conversation = database.Conversation(
+                mark_for_deletion=False,
+            )
+            conversation.id = conversation_id
+            db.session.add(conversation)
+            db.session.commit()
+            assert count(database.Conversation, id=conversation_id) == 1
+
+            # When deletion runs
+            deleted_count = Modifier.closed_conversations_deletion()
+
+            # Then the conversation is not deleted
+            assert deleted_count == 0
+            assert count(database.Conversation, id=conversation_id) == 1
+
+    def test_closed_conversations_deletion_rolls_back_on_message_delete_error(self):
+        # Given a conversation which has been marked_for_deletion
+        with self.app.app_context():
+            conversation_id = "conversation_id"
+            msg_id = "msg_id"
+
+            conversation = database.Conversation(mark_for_deletion=True)
+            conversation.id = conversation_id
+
+            message = database.SecureMessage(
+                msg_id=msg_id,
+                thread_id=conversation_id,
+            )
+            status = database.Status(msg_id=msg_id)
+
+            db.session.add_all([conversation, message, status])
+            db.session.commit()
+
+            assert count(database.Conversation, id=conversation_id) == 1
+            assert count(database.SecureMessage, msg_id=msg_id) == 1
+            assert count(database.Status, msg_id=msg_id) == 1
+
+            # When deletion runs, but an SQLAlchemyError is return on deleting SecureMessages
+            with patch(
+                "sqlalchemy.orm.query.Query.delete", side_effect=[1, SQLAlchemyError("secure message delete failed")]
+            ):
+                with pytest.raises(SQLAlchemyError):
+                    Modifier.closed_conversations_deletion()
+
+            # Then the conversation, secure message and status associated with it are not deleted
+            assert count(database.Conversation, id=conversation_id) == 1
+            assert count(database.SecureMessage, msg_id=msg_id) == 1
+            assert count(database.Status, msg_id=msg_id) == 1
+
+
+def count(model, **filters):
+    return db.session.query(model).filter_by(**filters).count()
 
 
 if __name__ == "__main__":

--- a/tests/endpoints/test_threads_endpoints.py
+++ b/tests/endpoints/test_threads_endpoints.py
@@ -9,7 +9,7 @@ from secure_message import application, constants
 from secure_message.authentication.jwt import encode
 from secure_message.repository import database
 from secure_message.repository.database import Conversation, SecureMessage
-from secure_message.resources.threads import ThreadMarkForDeletion, ThreadDeletion
+from secure_message.resources.threads import ThreadDeletion, ThreadMarkForDeletion
 
 
 class TestThreadsEndpoints(unittest.TestCase):

--- a/tests/endpoints/test_threads_endpoints.py
+++ b/tests/endpoints/test_threads_endpoints.py
@@ -9,7 +9,7 @@ from secure_message import application, constants
 from secure_message.authentication.jwt import encode
 from secure_message.repository import database
 from secure_message.repository.database import Conversation, SecureMessage
-from secure_message.resources.threads import ThreadMarkForDeletion
+from secure_message.resources.threads import ThreadMarkForDeletion, ThreadDeletion
 
 
 class TestThreadsEndpoints(unittest.TestCase):
@@ -274,3 +274,29 @@ class TestThreadsEndpoints(unittest.TestCase):
         self.assertEqual(status_code, 500)
         self.assertEqual(response, "")
         closed_conversations_mark_for_deletion.assert_called_once()
+
+    @patch("secure_message.repository.modifier.Modifier.closed_conversations_deletion")
+    def test_conversation_deletion_success(self, closed_conversations_deletion):
+        # Given a successful deletion returning a count
+        closed_conversations_deletion.return_value = 1
+
+        # When ThreadDeletion delete is called
+        response, status_code = ThreadDeletion.delete()
+
+        # Then a 204 response is returned
+        self.assertEqual(status_code, 204)
+        self.assertEqual(response, "")
+        closed_conversations_deletion.assert_called_once()
+
+    @patch("secure_message.repository.modifier.Modifier.closed_conversations_deletion")
+    def test_conversation_deletion_failure(self, closed_conversations_deletion):
+        # Given a mocked side effect of an SQLAlchemyError
+        closed_conversations_deletion.side_effect = SQLAlchemyError()
+
+        # When ThreadDeletion delete is called
+        response, status_code = ThreadDeletion.delete()
+
+        # Then a 500 error is returned
+        self.assertEqual(status_code, 500)
+        self.assertEqual(response, "")
+        closed_conversations_deletion.assert_called_once()


### PR DESCRIPTION
# What and why?
Creates an end point and endpoint to delete conversations (and related secure messages/statuses) that have been marke_for_deletion
# How to test?
Deploy this branch and helm chart (-p Deploy Version and Helm Chart ) then create a number of secure messages and responses, with at least one closed. For completeness I used both cron jobs sm-closed-conversations-mark-for-deletion and sm-closed-conversations-deletion. I changed the dates in the db of when conversations were closed and ran the former to change the mark_for_deletion status and the later to then delete. 

N.B There is still a gap which we need to discuss in a tech session. It's feasible a conversation could be re-opened in the 23 hours it has been marked for deletion and therefore should not be deleted. There is a number of ways we might want to tackle that

# Jira
