### PR TITLE
RAS-1917 reset Secure Message mark for deletion on re-opening

### DIFF
--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.100
+version: 2.1.101
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.100
+appVersion: 2.1.101

--- a/secure_message/repository/modifier.py
+++ b/secure_message/repository/modifier.py
@@ -223,6 +223,7 @@ class Modifier:
             metadata.closed_at = None
             metadata.closed_by = None
             metadata.closed_by_uuid = None
+            metadata.mark_for_deletion = False
             db.session.commit()
         except SQLAlchemyError:
             db.session.rollback()

--- a/tests/app/test_modifier.py
+++ b/tests/app/test_modifier.py
@@ -112,7 +112,13 @@ class ModifyTestCaseHelper:
         return thread_id
 
     def add_conversation(
-        self, conversation_id=str(uuid.uuid4()), is_closed=False, closed_by="", closed_by_uuid="", closed_at=None
+        self,
+        conversation_id=str(uuid.uuid4()),
+        is_closed=False,
+        closed_by="",
+        closed_by_uuid="",
+        closed_at=None,
+        mark_for_deletion=False,
     ):
         """Populate the conversation table"""
         # If conversation created needs to be closed, values are generated for you.  These can be overrriden
@@ -127,8 +133,10 @@ class ModifyTestCaseHelper:
                 closed_at = datetime.datetime.utcnow()
         with self.engine.begin() as con:
             query = (
-                f"INSERT INTO securemessage.conversation(id, is_closed, closed_by, closed_by_uuid, closed_at) "
-                f"VALUES('{conversation_id}', '{is_closed}', '{closed_by}', '{closed_by_uuid}', '{closed_at}')"
+                f"INSERT INTO securemessage.conversation(id, is_closed, closed_by, "
+                f"closed_by_uuid, closed_at, mark_for_deletion) "
+                f"VALUES('{conversation_id}', '{is_closed}', '{closed_by}', '{closed_by_uuid}', "
+                f"'{closed_at}', '{mark_for_deletion}')"
             )
             con.execute(text(query))
         return conversation_id
@@ -204,7 +212,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
 
     def test_open_conversation(self):
         """Test re-opening conversation works"""
-        conversation_id = self.add_conversation(is_closed=True)
+        conversation_id = self.add_conversation(is_closed=True, mark_for_deletion=True)
         with self.app.app_context():
             # msg_id is the same as thread id for a conversation of 1
             metadata = Retriever.retrieve_conversation_metadata(conversation_id)
@@ -214,6 +222,7 @@ class ModifyTestCase(unittest.TestCase, ModifyTestCaseHelper):
             self.assertIsNone(metadata.closed_by)
             self.assertIsNone(metadata.closed_by_uuid)
             self.assertIsNone(metadata.closed_at)
+            self.assertFalse(metadata.mark_for_deletion)
 
     def test_two_unread_labels_are_added_to_message(self):
         """testing duplicate message labels are not added to the database"""


### PR DESCRIPTION
# What and why?
This PR ensure that if a conversation is re-open it isn't marked for deletion 
# How to test?
Set a secure message to closed and marked for deletion. Open it back up and confirm it is not marked for deletion
# Jira
