### PR TITLE
Rename DATABASE_URL to DATABASE_URI and share postgres image with CI 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,20 +24,6 @@ jobs:
   build:
     name: Build & Package
     runs-on: ubuntu-latest
-    services:
-      # Label used to access the service container
-      postgres:
-        # Docker Hub image
-        image: postgres:9.4
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-        ports:
-          # Maps port 6379 on service container to the host
-          - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683	 # v4.2.2
         with:
@@ -49,6 +35,7 @@ jobs:
           python-version: '3.11'
       - name: Get Dependencies
         run: |
+          make start-db
           pip install pipenv
           pipenv install --dev --deploy
       - name: Run Tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: build start
+.PHONY: build start start-db
 
 build:
 	pipenv install --dev
+
+# The postgres image version is read from _infra/postgres-image, which CI uses too.
+start-db:
+	docker compose --env-file _infra/postgres-image up -d
 
 start:
 	pipenv run python run.py

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pipenv run python run.py
 ```
 or
 ```bash
-docker compose up
+make start-db
 ```
 or (when postgres is set up)
 ```bash
@@ -62,9 +62,10 @@ Ensure there is a postgres instance running on port 5432
 ```bash
 docker run -d -p 5432:5432 --name postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres -d postgres
 ```
-or you can use the docker-compose.yml file to create postgres
+or you can use the docker-compose.yml file to create postgres (this passes
+`--env-file _infra/postgres-image`, so local dev and CI share one postgres version)
 ```bash
-docker compose up
+make start-db
 ```
 
 Run the tests with make
@@ -102,7 +103,7 @@ Environment variables available for configuration are listed below:
 | SECURITY_USER_NAME       | Username for basic auth                         | N/A                                           |
 | SECURITY_USER_PASSWORD   | Password for basic auth                         | N/A                                           |
 | JWT_SECRET               | SECRET used to code JWT                         | N/A                                           |
-| DATABASE_URL             | Database URI                                    | postgresql://postgres:postgres@localhost:5432 |
+| DATABASE_URI             | Database URI                                    | postgresql://postgres:postgres@localhost:5432 |
 | NOTIFICATION_TEMPLATE_ID | Template id for Gov Notify service              | N/A                                           |
 | NOTIFY_VIA_GOV_NOTIFY    | Toggle for using Gov Notify for notifications   | '1' (enable Gov Notify email notifications)   |
 | PARTY_URL                | URL of the ras-party service                    | N/A                                           |

--- a/_infra/helm/secure-message/Chart.yaml
+++ b/_infra/helm/secure-message/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.108
+version: 2.1.109
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.108
+appVersion: 2.1.109

--- a/_infra/helm/secure-message/templates/deployment.yaml
+++ b/_infra/helm/secure-message/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
                 key: security-password
           - name: PORT
             value: "{{ .Values.container.port }}"
-          - name: DATABASE_URL
+          - name: DATABASE_URI
             {{- if .Values.database.sqlProxyEnabled }}
             value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@127.0.0.1:$(DB_PORT)/$(DB_NAME)"
             {{- else }}

--- a/_infra/postgres-image
+++ b/_infra/postgres-image
@@ -1,0 +1,2 @@
+POSTGRES_IMAGE=postgres:14
+

--- a/config.py
+++ b/config.py
@@ -14,7 +14,7 @@ class Config:
     """
 
     VERSION = "1.3.0"
-    DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432")
+    DATABASE_URI = os.getenv("DATABASE_URI", "postgresql://postgres:postgres@localhost:5432")
     LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO")
 
     # EMAIL NOTIFICATION SETTINGS
@@ -51,7 +51,7 @@ class Config:
 
     # SQLAlchemy
     SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv("SQLALCHEMY_TRACK_MODIFICATIONS", False)
-    SQLALCHEMY_DATABASE_URI = DATABASE_URL
+    SQLALCHEMY_DATABASE_URI = DATABASE_URI
 
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT", "ras-rm-sandbox")
     PUBSUB_TOPIC = os.getenv("PUBSUB_TOPIC", "ras-rm-notify-test")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '2'
-
 services:
   db:
-    image: postgres:9.6
+    # Single source of truth, shared with CI. Requires --env-file _infra/postgres-image,
+    # so start this with `make start-db` rather than a bare `docker compose up`.
+    image: ${POSTGRES_IMAGE}
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
@@ -11,6 +11,11 @@ services:
       - "5432:5432"
     networks:
       - secure
+    healthcheck:
+      test: pg_isready
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 networks:
   secure:

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -98,7 +98,7 @@ class AppTestCase(unittest.TestCase):
         url = "http://localhost:5050/messages"
 
         self.client.post(url, data=json.dumps(self.test_message), headers=self.internal_user_header)
-        engine = create_engine(self.app.config["DATABASE_URL"], echo=True)
+        engine = create_engine(self.app.config["DATABASE_URI"], echo=True)
         with engine.begin() as con:
             db_data = con.execute(
                 text(
@@ -144,7 +144,7 @@ class AppTestCase(unittest.TestCase):
 
         # Now read back the message to get the thread ID
 
-        engine = create_engine(self.app.config["DATABASE_URL"], echo=True)
+        engine = create_engine(self.app.config["DATABASE_URI"], echo=True)
         with engine.begin() as con:
             db_data = con.execute(
                 text(


### PR DESCRIPTION
# What and why?
DATABASE_URI is the convention across the other python services (6 of 7); this
was the only outlier. The chart assembles the value from the DB_* secrets rather
than reading a secret of this name, so the rename is self-contained.

The postgres version now lives in _infra/postgres-image, fed to docker-compose
via --env-file so local dev and CI share it, and bumped from the EOL 9.6 to 14.
Compose requires that flag, so use `make start-db` rather than `docker compose up`.

All of this is so the common Cloud Build pipeline we are developing for all Python
services has as few exceptions needed per-service as possible.

# How to test?
Run `make start-db start` and check if the service is working.

# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-1930
https://officefornationalstatistics.atlassian.net/wiki/spaces/SDC/pages/303956413/Spinnaker+Removal
